### PR TITLE
Add documentation and avoid GVRs with multiple energies

### DIFF
--- a/docs/source/examples/input/jupyters/ww.ipynb
+++ b/docs/source/examples/input/jupyters/ww.ipynb
@@ -102,9 +102,9 @@
     }
    ],
    "source": [
+    "import os\n",
     "import tempfile\n",
     "from pathlib import Path\n",
-    "import os\n",
     "\n",
     "# Normalize the weight window\n",
     "ww.multiply(1.2)\n",
@@ -193,6 +193,34 @@
     "### Use via a Command Line Interface\n",
     "The CLI can be invoked by `python -m f4enix.input.ww_gvr` \n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Theory\n",
+    "#### How the mitigate_long_histories method works\n",
+    "The weigth window voxels with a ratio higher than max_ratio will be set to zero. This stops the particle from over-splitting by removing the WW from the most problematic areas. The ratio of a voxel X is calculated as ${max}(V_x/V_i)$ where $V_x$ is the WW value of the voxel and $V_i$ are the WW values of the voxels neighboring voxel X.  \n",
+    "\n",
+    "#### Generation of a GVR\n",
+    "A GVR is generated using a FMESH file as input.The selected MESHTAL is loaded and processed as follows:\n",
+    "\n",
+    "$V_i = (\\frac{\\phi_i}{{max}(\\phi)} \\cdot \\frac{2}{\\beta + 1})^S$\n",
+    "\n",
+    "Where:\n",
+    "* $V_i$ is the WW value of the voxel i\n",
+    "* $\\phi_i$ is the neutron flux value at voxel i\n",
+    "* ${max}(\\phi)$ is the maximum neutron flux value found in the whole MESHTAL\n",
+    "* $\\beta$ is the mazimum splitting ratio (default 5)\n",
+    "* $S$ is the softening factor to mitigate the splitting (default 1)\n",
+    "\n",
+    "References:\n",
+    "1. A.J. van Wijk, G. Van den Eynde, J.E. Hoogenboom, An easy to implement global variance reduction procedure for MCNP, Annals of Nuclear Energy, Volume 38, Issue 11, 2011, Pages 2496-2503, ISSN 0306-4549, https://doi.org/10.1016/j.anucene.2011.07.037.\n",
+    "2. Andrew Davis, Andrew Turner, Comparison of global variance reduction techniques for Monte Carlo radiation transport simulations of ITER, Fusion Engineering and Design, Volume 86, Issues 9–11, 2011, Pages 2698-2700, ISSN 0920-3796, https://doi.org/10.1016/j.fusengdes.2011.01.059.\n",
+    "\n",
+    "#### Verification process\n",
+    "The module has been verified in a first step employing simple weight window meshes and verifying each single function. The WW values were manually input to easily check the results from typical operations. The reader and the plot function was endorsed double checking all possible sections. As these files are relatively small, the complete WW were double checked visually, parameter by parameter."
+   ]
   }
  ],
  "metadata": {
@@ -211,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/src/f4enix/input/ww_gvr/weight_window.py
+++ b/src/f4enix/input/ww_gvr/weight_window.py
@@ -98,8 +98,6 @@ class WW:
         """
         file_path = Path(file_path)
         parse_result = ww_parser.read_meshtally_file(file_path)
-        if len(parse_result.energies[0]) > 1:
-            raise ValueError("The meshtally file has more than one energy group.")
 
         geometry = cls._create_geometry(parse_result)
         values = cls._nested_to_values_by_particle(parse_result)

--- a/src/f4enix/input/ww_gvr/weight_window.py
+++ b/src/f4enix/input/ww_gvr/weight_window.py
@@ -98,6 +98,8 @@ class WW:
         """
         file_path = Path(file_path)
         parse_result = ww_parser.read_meshtally_file(file_path)
+        if len(parse_result.energies[0]) > 1:
+            raise ValueError("The meshtally file has more than one energy group.")
 
         geometry = cls._create_geometry(parse_result)
         values = cls._nested_to_values_by_particle(parse_result)

--- a/src/f4enix/input/ww_gvr/ww_parser.py
+++ b/src/f4enix/input/ww_gvr/ww_parser.py
@@ -210,6 +210,8 @@ def _read_header_from_meshtally_file(mesh: Fmesh) -> WWHeader:
     iv = 1  # It is always 1, time-dependent windows not supported
     ni = 1  # Number of particle types, always 1 when reading a meshtally
     nr = 10 if mesh.cart else 16
+    if len(mesh.ener) > 2:
+        raise ValueError("The meshtally file has more than one energy group.")
     ne = [1]  # Number of energy bins of each particle, always 1 for a meshtally
 
     # When reading a meshtally we consider that there are no regular intervals between

--- a/tests/test_ww_gvr/test_weight_window.py
+++ b/tests/test_ww_gvr/test_weight_window.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 import pyvista as pv
-from numpy.testing import assert_array_almost_equal
-
 from f4enix.input.ww_gvr.models import CoordinateType, ParticleType, Vectors
 from f4enix.input.ww_gvr.weight_window import WW
+from numpy.testing import assert_array_almost_equal
+
 from tests.test_ww_gvr.resources import expected_values_ww_complex_cart
 
 
@@ -147,6 +147,13 @@ def test_create_gvr_from_meshtally_file_cart():
         ww.values[ParticleType.NEUTRON][100.0] ** 0.5,
         softened_ww.values[ParticleType.NEUTRON][100.0],
     )
+
+
+def test_gvr_fails_if_multiple_energies():
+    with pytest.raises(ValueError):
+        WW.create_gvr_from_meshtally_file(
+            Path("tests") / "resources" / "meshtal" / "meshtal_rect_VV"
+        )
 
 
 def test_info():


### PR DESCRIPTION
# Description
Solves #92, theory documentation added at the end of the how to use WWs.

Now an error is raised if trying to generate a GVR from a meshtally that has more than one energy bin as it is theoretically incorrect.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update

# Testing

A new test has been added to ensure that an error is raised if trying to load a GVR from a methally with more than 1 energy bin.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%