### PR TITLE
Issue 93 shift ww coordinates

### DIFF
--- a/src/f4enix/input/ww_gvr/__init__.py
+++ b/src/f4enix/input/ww_gvr/__init__.py
@@ -1,2 +1,2 @@
+from f4enix.input.ww_gvr.models import CoordinateType, ParticleType
 from f4enix.input.ww_gvr.weight_window import WW
-from f4enix.input.ww_gvr.models import ParticleType, CoordinateType

--- a/src/f4enix/input/ww_gvr/geometry.py
+++ b/src/f4enix/input/ww_gvr/geometry.py
@@ -1,13 +1,12 @@
-from __future__ import annotations
-
 """
 This module contains the Geometry class, which is used to create a pyvista grid
 from the coarse and fine vectors of a WW file. It also contains the methods to
 fill the grid with the values of the WW file and to plot it.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Dict, List, Union
 
 import numpy as np
 import pyvista as pv
@@ -153,7 +152,7 @@ class Geometry:
         return compose_b2_vectors(self._coarse_vectors, self._fine_vectors)
 
     @property
-    def director_1(self) -> Union[List[float], None]:
+    def director_1(self) -> list[float] | None:
         """
         Returns the director 1 vector (axis) of the cylinder if the grid is
         cylindrical.
@@ -161,7 +160,7 @@ class Geometry:
         return self._director_1
 
     @property
-    def director_2(self) -> Union[List[float], None]:
+    def director_2(self) -> list[float] | None:
         """
         Returns the director 2 vector (radius) of the cylinder if the grid is
         cylindrical.
@@ -169,7 +168,7 @@ class Geometry:
         return self._director_2
 
     @property
-    def origin(self) -> List[float]:
+    def origin(self) -> list[float]:
         return self._origin
 
     @property
@@ -211,7 +210,7 @@ class Geometry:
         plotter.show_axes()  # type: ignore
         plotter.show()
 
-    def _decide_plot_parameters(self) -> Dict:
+    def _decide_plot_parameters(self) -> dict:
         sclar_bar_args = {
             "interactive": True,
             "title_font_size": 20,

--- a/src/f4enix/input/ww_gvr/models.py
+++ b/src/f4enix/input/ww_gvr/models.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 """
 Classes and types used throughout the package.
 """
 
+from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum

--- a/src/f4enix/input/ww_gvr/utils.py
+++ b/src/f4enix/input/ww_gvr/utils.py
@@ -1,8 +1,6 @@
 """
 Some utilities for the ww_gvr package.
 """
-
-from pathlib import Path
 from typing import Tuple
 
 import numpy as np
@@ -41,13 +39,13 @@ def decompose_b2_vectors(b2_vectors: Vectors) -> Tuple[Vectors, Vectors]:
     fine = []
 
     for b2_vector in b2_vectors:
-        b2_vector = np.insert(b2_vector, 1, 1.0000)
-        coarse.append([b2_vector[i] for i in range(len(b2_vector)) if i % 3 == 0])
+        vector = np.insert(b2_vector, 1, 1.0000)
+        coarse.append([vector[i] for i in range(len(vector)) if i % 3 == 0])
         fine.append(
             [
-                int(b2_vector[j + 2])
-                for j in range(len(b2_vector))
-                if j % 3 == 0 and j + 2 < len(b2_vector)
+                int(vector[j + 2])
+                for j in range(len(vector))
+                if j % 3 == 0 and j + 2 < len(vector)
             ]
         )
 

--- a/src/f4enix/input/ww_gvr/ww_parser.py
+++ b/src/f4enix/input/ww_gvr/ww_parser.py
@@ -14,6 +14,9 @@ from f4enix.input.ww_gvr.models import NestedList, Vectors
 from f4enix.input.ww_gvr.utils import compose_b2_vectors
 from f4enix.output.meshtal import Fmesh, Meshtal
 
+CARTESIAN_COORDINATES_ID = 10
+ALLOWED_NUMBER_OF_ENERGIES_IN_GVR = 1
+
 
 @dataclass()
 class WWHeader:
@@ -115,7 +118,7 @@ def _parse_header(infile: TextIO) -> WWHeader:
         "ncz": ncz,
     }
 
-    if nr == 10:  # Cartesian coordinates
+    if nr == CARTESIAN_COORDINATES_ID:
         header = WWHeader(**header_args)
     else:  # Cylindrical coordinates
         director_1 = [float(word) for word in words[3:]]
@@ -210,7 +213,7 @@ def _read_header_from_meshtally_file(mesh: Fmesh) -> WWHeader:
     iv = 1  # It is always 1, time-dependent windows not supported
     ni = 1  # Number of particle types, always 1 when reading a meshtally
     nr = 10 if mesh.cart else 16
-    if len(mesh.ener) > 2:
+    if len(mesh.ener) - 1 > ALLOWED_NUMBER_OF_ENERGIES_IN_GVR:
         raise ValueError("The meshtally file has more than one energy group.")
     ne = [1]  # Number of energy bins of each particle, always 1 for a meshtally
 
@@ -238,7 +241,7 @@ def _read_header_from_meshtally_file(mesh: Fmesh) -> WWHeader:
         "ncz": ncz,
     }
 
-    if nr == 10:  # Cartesian coordinates
+    if nr == CARTESIAN_COORDINATES_ID:
         header = WWHeader(**header_args)
     else:  # Cylindrical coordinates
         director_1 = mesh.axis.tolist()
@@ -344,8 +347,8 @@ def _write_header(f: TextIO, header: WWHeader) -> None:
 
 
 def _write_block_2(f: TextIO, b2_vectors: Vectors) -> None:
-    for vector in b2_vectors:
-        vector = vector.tolist()
+    for b2_vector in b2_vectors:
+        vector = b2_vector.tolist()
         packs_of_six = [vector[i : i + 6] for i in range(0, len(vector), 6)]
 
         for pack in packs_of_six:

--- a/src/f4enix/input/ww_gvr/ww_parser.py
+++ b/src/f4enix/input/ww_gvr/ww_parser.py
@@ -242,6 +242,8 @@ def _read_header_from_meshtally_file(mesh: Fmesh) -> WWHeader:
     }
 
     if nr == CARTESIAN_COORDINATES_ID:
+        # Origin should be zero for cartesian as the vectors start already at the origin
+        header_args["origin"] = [0, 0, 0]
         header = WWHeader(**header_args)
     else:  # Cylindrical coordinates
         director_1 = mesh.axis.tolist()

--- a/tests/test_ww_gvr/test_geometry.py
+++ b/tests/test_ww_gvr/test_geometry.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pyvista as pv
-
 from f4enix.input.ww_gvr.geometry import Geometry
 from f4enix.input.ww_gvr.models import ParticleType, Vectors
 from f4enix.input.ww_gvr.ww_parser import WWHeader, WWHeaderCyl
 
+# ruff: noqa: PLR2004
 
 def test_fill_grid_values_cart():
     header = WWHeader(

--- a/tests/test_ww_gvr/test_meshgrids.py
+++ b/tests/test_ww_gvr/test_meshgrids.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 import pyvista as pv
-from numpy.testing import assert_array_almost_equal, assert_array_equal
-
 from f4enix.input.ww_gvr.meshgrids import (
     _correct_theta_vector,
     _create_cylindrical_grid_with_z_axis,
@@ -10,6 +8,9 @@ from f4enix.input.ww_gvr.meshgrids import (
     create_cartesian_grid,
     create_cylindrical_grid,
 )
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+
+# ruff: noqa: PLR2004
 
 
 def test_create_cartesian_grid():

--- a/tests/test_ww_gvr/test_ratios_calculation.py
+++ b/tests/test_ww_gvr/test_ratios_calculation.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from f4enix.input.ww_gvr.ratios_calculation import calculate_max_ratio_array
 
 

--- a/tests/test_ww_gvr/test_utils.py
+++ b/tests/test_ww_gvr/test_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from f4enix.input.ww_gvr.utils import (
     Vectors,
     build_1d_vectors,
@@ -19,7 +18,6 @@ def test_vectors():
     for vector in vectors:
         iterated.append(vector)
     assert iterated[0].tolist() == vectors.vector_i.tolist()
-    assert vectors == vectors
 
     different = Vectors(
         vector_i=np.array([0.0, 2.0, 16.0, 1.0]),

--- a/tests/test_ww_gvr/test_weight_window.py
+++ b/tests/test_ww_gvr/test_weight_window.py
@@ -86,7 +86,7 @@ def test_values_setter_recalculates_ratios():
         Path("tests") / "test_ww_gvr" / "resources" / "ww_simple_cart"
     )
 
-    # Create a grid with 8 cells for convenience, Path("tests") / "test_ww_gvr" / "resources" / "ww_simple_cart" only has 6 cells
+    # Create a grid with 8 cells for convenience, "ww_simple_cart" only has 6 cells
     dummy_grid = pv.StructuredGrid()
     dummy_grid.dimensions = [3, 3, 3]
     ww.geometry._grid = dummy_grid

--- a/tests/test_ww_gvr/test_ww_parser.py
+++ b/tests/test_ww_gvr/test_ww_parser.py
@@ -121,7 +121,7 @@ def test_read_meshtally_file_cart():
         nfx=3,
         nfy=4,
         nfz=2,
-        origin=[-10.0, 20.0, 15.0],
+        origin=[0, 0, 0],
         ncx=3,
         ncy=4,
         ncz=2,

--- a/tests/test_ww_gvr/test_ww_parser.py
+++ b/tests/test_ww_gvr/test_ww_parser.py
@@ -1,8 +1,7 @@
-import numpy as np
 from pathlib import Path
 
+import numpy as np
 from f4enix.input.ww_gvr.models import Vectors
-
 from f4enix.input.ww_gvr.ww_parser import (
     WWHeader,
     WWHeaderCyl,
@@ -10,6 +9,8 @@ from f4enix.input.ww_gvr.ww_parser import (
     read_meshtally_file,
     write,
 )
+
+# ruff: noqa: PLR2004
 
 
 def test_parse_simple_cart():


### PR DESCRIPTION
# Description

The VTK export of a GVR of cartesian coordinates suffered an incorrect translation when the origin was not 0,0,0.

Fixes #93

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

# Testing

Tested doing a full workflow of creating a GVR from a FMESH file, exporting as VTK and then checking in Paraview that the coordinates were correct.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%