### PR TITLE
Addition of cell_union methods and fixing bugs with jt60,i test input

### DIFF
--- a/src/f4enix/input/MCNPinput.py
+++ b/src/f4enix/input/MCNPinput.py
@@ -1330,21 +1330,28 @@ class Input:
                 cell = self.cells[str(cell_num)]
                 self.hash_cell(cell, hash_id, inplace=True)
 
-    @staticmethod
-    def cell_union_function(
-        cell_list: list[parser.Card],
+    def cells_union(
+        self,
+        cell_num_list: list[str],
         new_cell_num: int = None,
-    ) -> parser.Card:
+    ) -> None:
         """Given a list of cells, it creates a new cell that is the union of
-        the cells in the list.
+        the cells in the list, starting from the first cell in the list.
+        The resulting cell will be put in the dict of cells
+        of the input (with the new number if provided), while the old cells will
+        be deleted. If a renumbering was done, the input must be re-read.
 
         Parameters
         ----------
         cell_list : list[parser.Card]
             list of cells to be united
         new_cell_num : int, optional
-            new number of the union cell, by default None
+            new number of the union cell, by default None (old number is kept).
         """
+
+        cell_list = []
+        for cell_num in cell_num_list:
+            cell_list.append(self.cells[cell_num])
 
         if new_cell_num is None:
             cel = cell_list[0]
@@ -1364,43 +1371,10 @@ class Input:
             new_cell = parser.Card(cell_lines, 3, new_cell.pos)
             new_cell.get_values()
 
-        return new_cell
+        for cell_num in cell_num_list:
+            self.cells.pop(cell_num)
 
-    def cells_union(
-        self,
-        cell_list: list[parser.Card],
-        remove_cells: bool = True,
-        add_union_cell: bool = True,
-        new_cell_num: int = None,
-    ) -> None:
-        """Given a list of cells, it creates a new cell that is the union of
-        the cells in the list. It also checks if the original cells must be removed or not
-        and if the new one has to be added to the input. If a renumbering was done,
-        the input must be re-read.
-
-        Parameters
-        ----------
-        cell_list : list[parser.Card]
-            list of cells to be united
-        remove_cells : bool, optional
-            Flag to check if the united cells have to be removed, by default True
-        add_union_cell : bool, optional
-            flag to check if the resultant cell has to be added to the input, by default True
-        new_cell_num : int, optional
-            new number of the union cell, by default None
-        """
-
-        if new_cell_num is None:
-            cel = cell_list[0]
-            new_cell_num = cel.values[0][0]
-
-        new_cell = Input.cell_union_function(cell_list, new_cell_num=new_cell_num)
-
-        if remove_cells:
-            for cell in cell_list:
-                self.cells.pop(str(cell.values[0][0]))
-        if add_union_cell:
-            self.cells[str(new_cell_num)] = new_cell
+        self.cells[str(new_cell_num)] = new_cell
 
     @staticmethod
     def _add_symbol_to_cell_input(

--- a/src/f4enix/input/MCNPinput.py
+++ b/src/f4enix/input/MCNPinput.py
@@ -1271,7 +1271,7 @@ class Input:
             )
 
         new_cell = Input._add_symbol_to_cell_input(
-            cell, template_addition, inplace=inplace
+            cell, template_addition, inplace=inplace, new_cell_num=new_cell_num
         )
 
         for k in range(len(new_cell.values) - 1, -1, -1):
@@ -1279,10 +1279,6 @@ class Input:
                 break
 
         new_cell.values.insert(k + 1, (abs(add_surface), "sur"))
-
-        if new_cell_num is not None:
-            new_cell.name = new_cell_num
-            new_cell._set_value_by_type("cel", new_cell_num)
 
         return new_cell
 
@@ -1308,7 +1304,7 @@ class Input:
         """
         template_addition = "#{:<" + str(len(str(hash_id)) - 1) + "} "
         new_cell = Input._add_symbol_to_cell_input(
-            cell, template_addition, inplace=inplace
+            cell, template_addition, inplace=inplace, new_cell_num=new_cell_num
         )
         # add the hash cell to the cell values
         for k in range(len(new_cell.values) - 1, -1, -1):
@@ -1316,11 +1312,6 @@ class Input:
                 break
 
         new_cell.values.insert(k + 1, (hash_id, "cel"))
-
-        # renumber the cell if requested
-        if new_cell_num is not None:
-            new_cell.name = new_cell_num
-            new_cell._set_value_by_type("cel", new_cell_num)
 
         return new_cell
 
@@ -1340,11 +1331,84 @@ class Input:
                 self.hash_cell(cell, hash_id, inplace=True)
 
     @staticmethod
+    def cell_union_function(
+        cell_list: list[parser.Card],
+        new_cell_num: int = None,
+    ) -> parser.Card:
+        """Given a list of cells, it creates a new cell that is the union of
+        the cells in the list.
+
+        Parameters
+        ----------
+        cell_list : list[parser.Card]
+            list of cells to be united
+        new_cell_num : int, optional
+            new number of the union cell, by default None
+        """
+
+        if new_cell_num is None:
+            cel = cell_list[0]
+            new_cell_num = cel.values[0][0]
+
+        new_cell = cell_list[0]
+
+        for cell in cell_list[1:]:
+            new_cell = Input._add_symbol_to_cell_input(
+                new_cell,
+                " : (" + cell.get_geom().replace("\n", " ") + ")",
+                inplace=False,
+                parentheses=True,
+                new_cell_num=new_cell_num,
+            )
+            cell_lines = new_cell.card(wrap=True).splitlines(keepends=True)
+            new_cell = parser.Card(cell_lines, 3, new_cell.pos)
+            new_cell.get_values()
+
+        return new_cell
+
+    def cells_union(
+        self,
+        cell_list: list[parser.Card],
+        remove_cells: bool = True,
+        add_union_cell: bool = True,
+        new_cell_num: int = None,
+    ) -> None:
+        """Given a list of cells, it creates a new cell that is the union of
+        the cells in the list. It also checks if the original cells must be removed or not
+        and if the new one has to be added to the input. If a renumbering was done,
+        the input must be re-read.
+
+        Parameters
+        ----------
+        cell_list : list[parser.Card]
+            list of cells to be united
+        remove_cells : bool, optional
+            Flag to check if the united cells have to be removed, by default True
+        add_union_cell : bool, optional
+            flag to check if the resultant cell has to be added to the input, by default True
+        new_cell_num : int, optional
+            new number of the union cell, by default None
+        """
+
+        if new_cell_num is None:
+            cel = cell_list[0]
+            new_cell_num = cel.values[0][0]
+
+        new_cell = Input.cell_union_function(cell_list, new_cell_num=new_cell_num)
+
+        if remove_cells:
+            for cell in cell_list:
+                self.cells.pop(str(cell.values[0][0]))
+        if add_union_cell:
+            self.cells[str(new_cell_num)] = new_cell
+
+    @staticmethod
     def _add_symbol_to_cell_input(
         cell: parser.Card,
         add_symbol: str,
         inplace: bool = True,
         parentheses: bool = True,
+        new_cell_num: int = None,
     ) -> parser.Card:
 
         if inplace:
@@ -1357,9 +1421,9 @@ class Input:
 
         if parentheses:
             if new_cell.get_m() == 0:
-                first_row[2] = "(" + first_row[2]
+                first_row[1] = first_row[1] + " ("
             else:
-                first_row[3] = "(" + first_row[3]
+                first_row[2] = first_row[2] + " ("
 
         new_cell.input[0] = " ".join(first_row)
 
@@ -1384,6 +1448,11 @@ class Input:
                 if new_cell.input[i][:5] != "     " and i != 0:
                     new_cell.input[i] = "     " + new_cell.input[i]
                 break
+
+        # renumber the cell if requested
+        if new_cell_num is not None:
+            new_cell.name = new_cell_num
+            new_cell._set_value_by_type("cel", new_cell_num)
 
         return new_cell
 
@@ -1501,8 +1570,8 @@ class Input:
 
         card = parser.Card([line], 5, -1)
         self.other_data["NPS"] = card
-    
-    def check_range(self, range: list[int], who: str = 'cell') -> bool:
+
+    def check_range(self, range: list[int], who: str = "cell") -> bool:
         """Check if the provided range is not within the used index, i.e., if the range
         is free. Both cells and surfaces can be checked.
 
@@ -1523,11 +1592,11 @@ class Input:
         ValueError
             only surf or cell are accepted as who
         """
-        if who == 'cell':
+        if who == "cell":
             used_index = self.cells.keys()
-        elif who == 'surf':
+        elif who == "surf":
             used_index = self.surfs.keys()
-        else:   
+        else:
             raise ValueError("who can be only 'cell' or 'surf'")
         # check that the provided range is not within the used index
         # need to do the check for strings since there may be asterisks
@@ -1536,7 +1605,6 @@ class Input:
                 if str(i) in j:  # that's for the asterisk problem
                     return False
         return True
-        
 
 
 class D1S_Input(Input):

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -428,73 +428,29 @@ class TestInput:
         assert newinp.cells["299"].get_m() == 10
         assert newinp.cells["1"].get_m() == 0
 
-    def test_cell_union_function(self):
-        newinput = deepcopy(self.testInput)
-        assert (
-            Input.cell_union_function([newinput.cells["1"], newinput.cells["2"]]).card()
-            == "1 0 ( -128 129 -1 )  : (  -128 129 1   -2 )$imp:n,p=1\n"
-        )
-        with as_file(resources_inp.joinpath("test_universe.i")) as inp_file:
-            newinp = Input.from_input(inp_file)
-        assert (
-            Input.cell_union_function([newinp.cells["1"], newinp.cells["22"]]).card()
-            == "1 0 ( -1 )  : (      -22 ) imp:n=1 fill=125\n"
-        )
-        # assert (
-        #     Input.cell_union_function([newinp.cells["299"], newinp.cells["99"]]).card()
-        #     == "299 0 (#21 #22 )  : ( 1 ) imp:n=1 u=125\n"
-        # )
-        assert (
-            Input.cell_union_function(
-                [newinp.cells["299"], newinp.cells["99"], newinp.cells["22"]]
-            ).card()
-            == "299 0 ( ( #21 #22 ) : ( 1 ) )  : (      -22 ) imp:n=1 u=125\n"
-        )
-        assert (
-            Input.cell_union_function(
-                [newinp.cells["299"], newinp.cells["99"], newinp.cells["22"]], 500
-            ).values[0][0]
-            == 500
-        )
-
     def test_cells_union(self):
         with as_file(resources_inp.joinpath("test_universe.i")) as inp_file:
             newinp = Input.from_input(inp_file)
-        new_cell = newinp.cells_union(
-            [newinp.cells["1"], newinp.cells["22"], newinp.cells["299"]], False, False
-        )
-        assert "1" in newinp.cells
-        assert "22" in newinp.cells
-        assert "299" in newinp.cells
-        new_cell = newinp.cells_union(
-            [newinp.cells["1"], newinp.cells["22"], newinp.cells["299"]]
-        )
-        assert "1" in newinp.cells
-        assert not "22" in newinp.cells
-        assert not "299" in newinp.cells
 
-        with as_file(resources_inp.joinpath("jt60.i")) as inp_file:
-            newinp = Input.from_input(inp_file)
-        new_cell = newinp.cells_union(
-            [newinp.cells["1"], newinp.cells["22"], newinp.cells["299"]],
-            False,
-            True,
-            300000,
-        )
+        newinp_2 = deepcopy(newinp)
+
+        newinp.cells_union(["1", "22", "299"], None)
         assert "1" in newinp.cells
-        assert "22" in newinp.cells
-        assert "299" in newinp.cells
-        assert "300000" in newinp.cells
-        new_cell = newinp.cells_union(
-            [newinp.cells["1"], newinp.cells["22"], newinp.cells["299"]],
-            True,
-            True,
-            300000,
-        )
-        assert not "1" in newinp.cells
         assert not "22" in newinp.cells
         assert not "299" in newinp.cells
-        assert "300000" in newinp.cells
+        assert (
+            newinp.cells["1"].card()
+            == "1 0 ( ( -1 ) : ( -22 ) )  : ( #21 #22    ) imp:n=1 fill=125\n"
+        )
+        newinp_2.cells_union(["22", "299", "1"], 635)
+        assert not "1" in newinp_2.cells
+        assert not "22" in newinp_2.cells
+        assert not "299" in newinp_2.cells
+        assert "635" in newinp_2.cells
+        assert (
+            newinp_2.cells["635"].card()
+            == "635 0 ( ( -22 ) : ( #21 #22 ) )  : ( -1 ) imp:n=1\n        U=125\n"
+        )
 
     def test_add_surface(self):
         newinput = deepcopy(self.testInput)

--- a/tests/elite_test.py
+++ b/tests/elite_test.py
@@ -151,8 +151,8 @@ class TestElite_Input:
         new_outercell, new_gy = inp._modify_graveyard(sectors, outercell, graveyard)
         print_outercell = new_outercell.card(wrap=True, comment=False).splitlines()
         print_gy = new_gy.card(wrap=True, comment=False).splitlines()
-        assert print_outercell[0].split()[2][:2] == "(("
-        assert print_gy[0].split()[2][:2] == "(("
+        assert print_outercell[0].split()[2][:2] == "("
+        assert print_gy[0].split()[2][:2] == "("
         assert ") 427024 ) 427016" in print_outercell[0]
         assert ") :-427024 ) :-427016" in print_gy[0]
 
@@ -160,8 +160,8 @@ class TestElite_Input:
         new_outercell, new_gy = inp._modify_graveyard(sectors, outercell, graveyard)
         print_outercell = new_outercell.card(wrap=True, comment=False).splitlines()
         print_gy = new_gy.card(wrap=True, comment=False).splitlines()
-        assert print_outercell[0].split()[2][:2] == "(("
-        assert print_gy[0].split()[2][:2] == "(("
+        assert print_outercell[0].split()[2][:2] == "("
+        assert print_gy[0].split()[2][:2] == "("
         assert ") -437544 ) 437543" in print_outercell[0]
         assert ") :437544 ) :-437543" in print_gy[0]
 
@@ -169,8 +169,8 @@ class TestElite_Input:
         new_outercell, new_gy = inp._modify_graveyard(sectors, outercell, graveyard)
         print_outercell = new_outercell.card(wrap=True, comment=False).splitlines()
         print_gy = new_gy.card(wrap=True, comment=False).splitlines()
-        assert print_outercell[0].split()[2][:2] == "(("
-        assert print_gy[0].split()[2][:2] == "(("
+        assert print_outercell[0].split()[2][:2] == "("
+        assert print_gy[0].split()[2][:2] == "("
         assert ") 427024 ) 437543" in print_outercell[0]
         assert ") :-427024 ) :-437543" in print_gy[0]
 


### PR DESCRIPTION
# Description

Two new methods to make the union of cells have been introduced. Also, methods using _add_symbol_to_cell_input were failing wit jt60.i test input, since the cells in this input are defined so that the input goes to newline after cell definition. This has been fixed, but some tests have to be revised

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

# Testing

All tests pass and new tests were introduced for the new methods

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [ x] Coverage is >80%