### PR TITLE
Set cell and surfaces as properties of the Input class

### DIFF
--- a/docs/source/examples/input/jupyters/mcnp_inp.ipynb
+++ b/docs/source/examples/input/jupyters/mcnp_inp.ipynb
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/tutorial/tutorial.ipynb
+++ b/docs/source/tutorial/tutorial.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/src/f4enix/input/MCNPinput.py
+++ b/src/f4enix/input/MCNPinput.py
@@ -54,6 +54,11 @@ class CardsDict(dict):
         super().__init__(*args, **kwargs)
         self.card_type = card_type
 
+    def update(self, *args, **kwargs):
+        """Override the update method to customize how entries are added."""
+        for key, value in dict(*args, **kwargs).items():
+            self[key] = value
+
     def __setitem__(self, key, value):
         """Override the __setitem__ method to customize how entries are added."""
 

--- a/src/f4enix/input/auxiliary.py
+++ b/src/f4enix/input/auxiliary.py
@@ -16,10 +16,12 @@ CONDITIONS OF ANY KIND, either express or implied. See the Licence permissions
 and limitations under the Licence.
 """
 
-from numjuggler.parser import Card
-from f4enix.constants import PAT_DOLLAR_COMMENT, PAT_COMMENT_TEXT
-import re
 import os
+import re
+
+from numjuggler.parser import Card
+
+from f4enix.constants import PAT_COMMENT_TEXT, PAT_DOLLAR_COMMENT
 
 _surrogates = re.compile(r"[\uDC80-\uDCFF]")
 
@@ -63,13 +65,13 @@ def _detect_decoding_errors_line(l, _s=_surrogates.finditer):  # pragma: no cove
     return [(m.start(), bytes([ord(m.group()) - 0xDC00])) for m in _s(l)]
 
 
-def debug_file_unicode(file: os.PathLike) -> str:  # pragma: no cover
+def debug_file_unicode(file: os.PathLike | str) -> str:  # pragma: no cover
     """given a file prints the unicode error that were found and at what
     line
 
     Parameters
     ----------
-    file : os.PathLike
+    file : os.PathLike | str
         file to be debugged
 
     Returns

--- a/src/f4enix/input/auxiliary.py
+++ b/src/f4enix/input/auxiliary.py
@@ -3,6 +3,8 @@ Auxiliary functions used by different modules
 
 """
 
+from __future__ import annotations
+
 """
 Copyright 2019 F4E | European Joint Undertaking for ITER and the Development of
 Fusion Energy (‘Fusion for Energy’). Licensed under the EUPL, Version 1.2 or - 

--- a/src/f4enix/input/d1suned.py
+++ b/src/f4enix/input/d1suned.py
@@ -20,9 +20,9 @@ CONDITIONS OF ANY KIND, either express or implied. See the Licence permissions
 and limitations under the Licence.
 """
 
-import re
-import os
 import logging
+import os
+import re
 
 from f4enix.constants import PAT_BLANK, PAT_COMMENT, PAT_SPACE
 from f4enix.input.libmanager import LibManager
@@ -33,12 +33,11 @@ REACFORMAT = "{:>13s}{:>7s}{:>12s}{:>40s}"
 
 
 class IrradiationFile:
-
     def __init__(
         self,
         nsc: int,
         irr_schedules: list[Irradiation],
-        header: str = None,
+        header: str | None = None,
         formatting: list[int] = [11, 14, 13, 9],
         name: str = "irrad",
     ) -> None:
@@ -161,7 +160,7 @@ class IrradiationFile:
         return None
 
     @classmethod
-    def from_text(cls, filepath: os.PathLike) -> IrradiationFile:
+    def from_text(cls, filepath: os.PathLike | str) -> IrradiationFile:
         """
         Initialize an IrradiationFile object directly parsing and existing
         irradiation file
@@ -170,7 +169,7 @@ class IrradiationFile:
         ----------
         cls : TYPE
             DESCRIPTION.
-        filepath : os.PathLike
+        filepath : os.PathLike | str
             path to the existing irradiation file.
 
         Returns
@@ -202,7 +201,6 @@ class IrradiationFile:
                         PAT_BLANK.match(line) is None
                         and PAT_COMMENT.match(line) is None
                     ):
-
                         irr_schedules.append(Irradiation.from_text(line, nsc))
 
         logging.info("{} correctly parsed".format(filepath))
@@ -274,7 +272,7 @@ class IrradiationFile:
 
 class Irradiation:
     def __init__(
-        self, daughter: str, lambd: str, times: list[str], comment: str = None
+        self, daughter: str, lambd: str, times: list[str], comment: str | None = None
     ) -> None:
         """
         Irradiation object
@@ -397,9 +395,7 @@ Daughter: {}
 lambda [1/s]: {}
 times: {}
 comment: {}
-""".format(
-            self.daughter, self.lambd, self.times, self.comment
-        )
+""".format(self.daughter, self.lambd, self.times, self.comment)
 
         return text
 
@@ -444,7 +440,7 @@ class ReactionFile:
         self.name = name
 
     @classmethod
-    def from_text(cls, filepath: os.PathLike) -> ReactionFile:
+    def from_text(cls, filepath: os.PathLike | str) -> ReactionFile:
         """
         Generate a reaction file directly from text file
 
@@ -452,7 +448,7 @@ class ReactionFile:
         ----------
         cls : TYPE
             DESCRIPTION.
-        filepath : os.PathLike
+        filepath : os.PathLike | str
             file to read.
 
         Returns
@@ -660,9 +656,7 @@ parent: {}
 MT channel: {}
 daughter: {}
 comment: {}
-""".format(
-            self.parent, self.MT, self.daughter, self.comment
-        )
+""".format(self.parent, self.MT, self.daughter, self.comment)
         return text
 
     @classmethod

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -68,6 +68,13 @@ class TestInput:
         with pytest.raises(ValueError):
             inp.cells["5"] = 1
 
+        # verify that also the dictionary update works as expected
+        inp.cells.update({"4": deepcopy(inp.cells["1"]), "2": deepcopy(inp.cells["1"])})
+        assert inp.cells["4"].name == 4
+        assert inp.cells["4"].values[0] == (4, "cel")
+        assert inp.cells["2"].name == 2
+        assert inp.cells["2"].values[0] == (2, "cel")
+
     def test_surf_property(self):
         inp = deepcopy(self.testInput)
         # verify that the name and values have been changed

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -62,6 +62,12 @@ class TestInput:
         assert inp.cells["3"].name == 3
         assert inp.cells["3"].values[0] == (3, "cel")
 
+        # no random stuff can be added to the dictionary
+        with pytest.raises(ValueError):
+            inp.cells[1] = inp.cells["1"]
+        with pytest.raises(ValueError):
+            inp.cells["5"] = 1
+
     def test_surf_property(self):
         inp = deepcopy(self.testInput)
         # verify that the name and values have been changed

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -1,18 +1,18 @@
 import os
-import numpy as np
-import pytest
 from copy import deepcopy
-from importlib.resources import files, as_file
+from importlib.resources import as_file, files
+
+import numpy as np
+import pandas as pd
+import pytest
 from numjuggler import parser
+
 import f4enix.resources as pkg_res
 import tests.resources.input as input_res
 import tests.resources.libmanager as lib_res
-import pandas as pd
-
-from f4enix.input.MCNPinput import Input, D1S_Input
+from f4enix.input.d1suned import IrradiationFile, ReactionFile
 from f4enix.input.libmanager import LibManager
-from f4enix.input.d1suned import ReactionFile, IrradiationFile
-
+from f4enix.input.MCNPinput import D1S_Input, Input
 
 resources_inp = files(input_res)
 resources_lib = files(lib_res)
@@ -48,6 +48,32 @@ class TestInput:
         assert not inp.check_range([1, 2])
         assert inp.check_range(range(1000, 10010))
         assert not inp.check_range([1, 1e4])
+
+    def test_cell_property(self):
+        inp = deepcopy(self.testInput)
+        # verify that the name and values have been changed
+        inp.cells = {"1": inp.cells["1"], "2": inp.cells["1"]}
+        assert inp.cells["2"].name == 2
+        assert inp.cells["2"].values[0] == (2, "cel")
+
+        # adding a new value should still force the keys and names to be
+        # the same
+        inp.cells["3"] = deepcopy(inp.cells["1"])
+        assert inp.cells["3"].name == 3
+        assert inp.cells["3"].values[0] == (3, "cel")
+
+    def test_surf_property(self):
+        inp = deepcopy(self.testInput)
+        # verify that the name and values have been changed
+        inp.surfs = {"1": inp.surfs["1"], "2": inp.surfs["1"]}
+        assert inp.surfs["2"].name == 2
+        assert inp.surfs["2"].values[0] == (2, "sur")
+
+        # adding a new value should still force the keys and names to be
+        # the same
+        inp.surfs["3"] = deepcopy(inp.surfs["1"])
+        assert inp.surfs["3"].name == 3
+        assert inp.surfs["3"].values[0] == (3, "sur")
 
     def test_from_input(self):
         inp = deepcopy(self.testInput)


### PR DESCRIPTION
# Description

This PR protects the cells and surfs properties of the input class to enforce that the name, value and key of the cell or the surface are coherent. This also required to extend the dict class to override the __set_item__() method.

Some effort has also been done to improve/update the type hinting but more work is needed across the entire repository for that

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update

# Testing

Suitable tests have been added to the CI suite

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%