### PR TITLE
expand support to python 3.12

### DIFF
--- a/.github/workflows/AutomatedTests_linux.yml
+++ b/.github/workflows/AutomatedTests_linux.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/AutomatedTests_win.yml
+++ b/.github/workflows/AutomatedTests_win.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -5,7 +5,7 @@ myst_nb
 pydata-sphinx-theme
 # F4Enix reqs
 numpy <= 1.26.4
-numjuggler
+numjuggler >= 2.42.37
 pyvista >= 0.39.1
 pandas
 numba

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy <= 1.26.4",
-    "numjuggler",
+    "numjuggler >= 2.42.37",
     "pyvista >= 0.39.1",
     "pandas",
     "numba",

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -445,10 +445,9 @@ class TestInput:
     def test_set_cell_void(self):
         newinput = deepcopy(self.testInput)
         Input.set_cell_void(newinput.cells["49"])
-        assert (
-            newinput.cells["49"].card()
-            == "49   0     -128 129 48  -49               $imp:n,p=1\r\n"
-        )
+        text = newinput.cells["49"].card()
+        text = text.replace("\r", "")
+        assert text == "49   0     -128 129 48  -49               $imp:n,p=1\n"
 
     def test_replace_material(self):
         with as_file(resources_inp.joinpath("test_universe.i")) as inp_file:
@@ -477,18 +476,19 @@ class TestInput:
         assert "1" in newinp.cells
         assert not "22" in newinp.cells
         assert not "299" in newinp.cells
-        assert (
-            newinp.cells["1"].card()
-            == "1 0 ( ( -1 ) : ( -22 ) )  : ( #21 #22    ) imp:n=1 fill=125\n"
-        )
+        text = newinp.cells["1"].card()
+        text = text.replace("\r", "")
+        assert text == "1 0 ( ( -1 ) : ( -22 ) )  : ( #21 #22    ) imp:n=1 fill=125\n"
+
         newinp_2.cells_union(["22", "299", "1"], 635)
         assert not "1" in newinp_2.cells
         assert not "22" in newinp_2.cells
         assert not "299" in newinp_2.cells
         assert "635" in newinp_2.cells
+        text = newinp_2.cells["635"].card()
+        text = text.replace("\r", "")
         assert (
-            newinp_2.cells["635"].card()
-            == "635 0 ( ( -22 ) : ( #21 #22 ) )  : ( -1 ) imp:n=1\n        U=125\r\n"
+            text == "635 0 ( ( -22 ) : ( #21 #22 ) )  : ( -1 ) imp:n=1\n        U=125\n"
         )
 
     def test_add_surface(self):


### PR DESCRIPTION
# Description

Expand the support to Python 3.12 thanks to the new numjuggler release.


Additional dependencies introduced.
- numjuggler > 2.42.37

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update

# Testing

Tests are to be performed in the GitHub CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%