### PR TITLE
fix TF card bug

### DIFF
--- a/src/f4enix/input/MCNPinput.py
+++ b/src/f4enix/input/MCNPinput.py
@@ -1033,6 +1033,9 @@ class Input:
         key = key.upper()
         try:
             newkey = PAT_F_TR_CARD_KEY.search(key).group()
+            # handle the TF edge case
+            if "TF" in key.upper():
+                newkey = "T" + newkey
         except AttributeError:
             logging.debug("the following key was not cleaned: " + key)
             newkey = key

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -362,12 +362,21 @@ class TestInput:
         self.bugInput.get_materials_subset(["m101"])
         assert True
 
-    def test_missing_data_cards(self):
-        _ = self.bugInput.other_data["SP2"]
-        _ = self.bugInput.transformations["TR1"]
-        _ = self.bugInput.other_data["CUT:N"]
-        _ = self.bugInput.other_data["WWN1:P"]
-        _ = self.bugInput.other_data["WWN1:N"]
+    def test_missing_data_cards(self, tmpdir):
+        # Check that all these data do not go missing after a rewrite
+        with as_file(resources_inp.joinpath("various_bugs.i")) as file:
+            inp = Input.from_input(file)
+        inp.write(tmpdir.join("bug.i"))
+
+        reinp = Input.from_input(tmpdir.join("bug.i"))
+        _ = reinp.other_data["SP2"]
+        _ = reinp.transformations["TR1"]
+        _ = reinp.other_data["CUT:N"]
+        _ = reinp.other_data["WWN1:P"]
+        _ = reinp.other_data["WWN1:N"]
+        _ = reinp.other_data["F96"]
+        _ = reinp.other_data["F30004"]
+        _ = reinp.other_data["TF30004"]
 
         assert True
 
@@ -378,6 +387,7 @@ class TestInput:
             ["f6:n,p", "F6"],
             ["WWN1:n", "WWN1:N"],
             ["WWE:n", "WWE:N"],
+            ["TF300004", "TF300004"],
         ],
     )
     def test_clean_card_name(self, cardname, clean_name):

--- a/tests/resources/input/various_bugs.i
+++ b/tests/resources/input/various_bugs.i
@@ -269,6 +269,16 @@ F96:N,P  101
 SD96     1
 FM96     3.1611E+06
 TF96     1 7J
+C Flux
+C
+FC30004   TFC WP IB STR Y+ U=1053 FLUX, NEUTRON, 1 RAD.LAYER, 2+ SEG.1-8+TOTAL
+F30004:N  ((310004 159I 310164)<428053)
+FS30004    6057 -6058 -6002 5I -6008 T
+SD30004    1 10R
+FM30004    1.7757E+20
+FQ30004    S F
+TF30004    1 2J 6 4J
+C
 C ----------------------------------------------------------------------------C
 C    TRANSFORMATIONS                                                          C
 C    ROTATION WITH RESPECT TO Z-AXIS (-20,|5|,20)                             C


### PR DESCRIPTION
# Description

There is a fairly new clean_card function in F4Enix that identifies FMESH, TR and F cards to clean them from additional clutter such as :N,P* etc. 

In the edge case of TF cards, one between the F and the TF card was being deleted.

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update

# Testing

Added suitable tests on the CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%