### PR TITLE
allow for hasslefree treatment of dosimetry libraries

### DIFF
--- a/docs/source/examples/input/jupyters/mcnp_inp.ipynb
+++ b/docs/source/examples/input/jupyters/mcnp_inp.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,18 +41,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'1': <numjuggler.parser.Card object at 0x000001CF6B164A00>, '2': <numjuggler.parser.Card object at 0x000001CF6B1641C0>, '3': <numjuggler.parser.Card object at 0x000001CF6B164DC0>, '4': <numjuggler.parser.Card object at 0x000001CF6B164310>, '5': <numjuggler.parser.Card object at 0x000001CF6B164490>, '6': <numjuggler.parser.Card object at 0x000001CF6B1645B0>, '7': <numjuggler.parser.Card object at 0x000001CF6B164430>, '8': <numjuggler.parser.Card object at 0x000001CF6B1646D0>, '9': <numjuggler.parser.Card object at 0x000001CF6B164D90>, '10': <numjuggler.parser.Card object at 0x000001CF6B164AF0>, '11': <numjuggler.parser.Card object at 0x000001CF6B164A60>, '12': <numjuggler.parser.Card object at 0x000001CF6B164C40>, '13': <numjuggler.parser.Card object at 0x000001CF6B1647C0>, '14': <numjuggler.parser.Card object at 0x000001CF6B1647F0>, '15': <numjuggler.parser.Card object at 0x000001CF6B1642B0>, '16': <numjuggler.parser.Card object at 0x000001CF6B164850>, '17': <numjuggler.parser.Card object at 0x000001CF6B164280>, '18': <numjuggler.parser.Card object at 0x000001CF6B164AC0>, '19': <numjuggler.parser.Card object at 0x000001CF6B164250>, '20': <numjuggler.parser.Card object at 0x000001CF6B1642E0>, '21': <numjuggler.parser.Card object at 0x000001CF6B164CD0>, '22': <numjuggler.parser.Card object at 0x000001CF6B164610>, '23': <numjuggler.parser.Card object at 0x000001CF6B164700>, '24': <numjuggler.parser.Card object at 0x000001CF6B1645E0>, '25': <numjuggler.parser.Card object at 0x000001CF6B164D00>, '26': <numjuggler.parser.Card object at 0x000001CF6B17A040>, '27': <numjuggler.parser.Card object at 0x000001CF6B17AFA0>, '28': <numjuggler.parser.Card object at 0x000001CF6B17A5E0>, '29': <numjuggler.parser.Card object at 0x000001CF6B17A1F0>, '30': <numjuggler.parser.Card object at 0x000001CF6B17A130>, '31': <numjuggler.parser.Card object at 0x000001CF6B17AD30>, '32': <numjuggler.parser.Card object at 0x000001CF6B17A3A0>, '33': <numjuggler.parser.Card object at 0x000001CF6B17A2B0>, '34': <numjuggler.parser.Card object at 0x000001CF6B17A3D0>, '35': <numjuggler.parser.Card object at 0x000001CF6B17A880>, '36': <numjuggler.parser.Card object at 0x000001CF6B17A670>, '37': <numjuggler.parser.Card object at 0x000001CF6B17A5B0>, '38': <numjuggler.parser.Card object at 0x000001CF6B17ABE0>, '39': <numjuggler.parser.Card object at 0x000001CF6B17A8B0>, '40': <numjuggler.parser.Card object at 0x000001CF6B17A7F0>, '41': <numjuggler.parser.Card object at 0x000001CF6B17A4F0>, '42': <numjuggler.parser.Card object at 0x000001CF6B17A730>, '43': <numjuggler.parser.Card object at 0x000001CF6B17A6A0>, '44': <numjuggler.parser.Card object at 0x000001CF6B17A700>, '45': <numjuggler.parser.Card object at 0x000001CF6B17AD00>, '46': <numjuggler.parser.Card object at 0x000001CF6B17A160>, '47': <numjuggler.parser.Card object at 0x000001CF6B17AC10>, '48': <numjuggler.parser.Card object at 0x000001CF6B17AA60>, '49': <numjuggler.parser.Card object at 0x000001CF6B17A970>, '50': <numjuggler.parser.Card object at 0x000001CF6B17AAC0>, '51': <numjuggler.parser.Card object at 0x000001CF69F8FCD0>, '52': <numjuggler.parser.Card object at 0x000001CF69F8FB20>, '53': <numjuggler.parser.Card object at 0x000001CF69F8FCA0>, '54': <numjuggler.parser.Card object at 0x000001CF69F8FC70>, '55': <numjuggler.parser.Card object at 0x000001CF69F8FBB0>, '56': <numjuggler.parser.Card object at 0x000001CF69F8FC10>, '57': <numjuggler.parser.Card object at 0x000001CF69F8FBE0>, '58': <numjuggler.parser.Card object at 0x000001CF69F8FB80>, '59': <numjuggler.parser.Card object at 0x000001CF69F8FB50>, '60': <numjuggler.parser.Card object at 0x000001CF69F8FAF0>, '61': <numjuggler.parser.Card object at 0x000001CF69F8FAC0>, '62': <numjuggler.parser.Card object at 0x000001CF69F8FA60>, '63': <numjuggler.parser.Card object at 0x000001CF69F8FA90>, '64': <numjuggler.parser.Card object at 0x000001CF69F8FA30>, '65': <numjuggler.parser.Card object at 0x000001CF69F8F9D0>, '66': <numjuggler.parser.Card object at 0x000001CF69F8FA00>, '67': <numjuggler.parser.Card object at 0x000001CF69F8F9A0>, '68': <numjuggler.parser.Card object at 0x000001CF69F8F940>, '69': <numjuggler.parser.Card object at 0x000001CF69F8F970>, '70': <numjuggler.parser.Card object at 0x000001CF69F8F910>, '71': <numjuggler.parser.Card object at 0x000001CF69F8F8E0>, '72': <numjuggler.parser.Card object at 0x000001CF69F8F880>, '73': <numjuggler.parser.Card object at 0x000001CF69F8F820>, '74': <numjuggler.parser.Card object at 0x000001CF69F8F850>, '75': <numjuggler.parser.Card object at 0x000001CF69F8F7F0>, '76': <numjuggler.parser.Card object at 0x000001CF69F8F790>, '77': <numjuggler.parser.Card object at 0x000001CF69F8F7C0>, '78': <numjuggler.parser.Card object at 0x000001CF69F8F760>, '79': <numjuggler.parser.Card object at 0x000001CF69F8F700>, '80': <numjuggler.parser.Card object at 0x000001CF69F8F730>, '81': <numjuggler.parser.Card object at 0x000001CF69F8F6D0>, '82': <numjuggler.parser.Card object at 0x000001CF69F8F670>, '83': <numjuggler.parser.Card object at 0x000001CF69F8F6A0>, '84': <numjuggler.parser.Card object at 0x000001CF69F8F640>, '85': <numjuggler.parser.Card object at 0x000001CF69F8F610>, '86': <numjuggler.parser.Card object at 0x000001CF69F8F5B0>, '87': <numjuggler.parser.Card object at 0x000001CF69F8F550>, '88': <numjuggler.parser.Card object at 0x000001CF69F8F580>, '89': <numjuggler.parser.Card object at 0x000001CF69F8F520>, '90': <numjuggler.parser.Card object at 0x000001CF69F8F4C0>, '91': <numjuggler.parser.Card object at 0x000001CF69F8F4F0>, '92': <numjuggler.parser.Card object at 0x000001CF69F8F490>, '93': <numjuggler.parser.Card object at 0x000001CF69F8F460>, '94': <numjuggler.parser.Card object at 0x000001CF69F8F430>, '95': <numjuggler.parser.Card object at 0x000001CF69F8F400>, '96': <numjuggler.parser.Card object at 0x000001CF69F8F3D0>, '97': <numjuggler.parser.Card object at 0x000001CF69F8F3A0>, '98': <numjuggler.parser.Card object at 0x000001CF69F8F370>, '99': <numjuggler.parser.Card object at 0x000001CF69F8F340>, '100': <numjuggler.parser.Card object at 0x000001CF69F8F310>, '101': <numjuggler.parser.Card object at 0x000001CF69F8F2E0>, '102': <numjuggler.parser.Card object at 0x000001CF69F8F2B0>, '103': <numjuggler.parser.Card object at 0x000001CF69F8F280>, '104': <numjuggler.parser.Card object at 0x000001CF69F8F250>, '105': <numjuggler.parser.Card object at 0x000001CF69F8F220>, '106': <numjuggler.parser.Card object at 0x000001CF69F8F1C0>}\n",
-      "{'1': <numjuggler.parser.Card object at 0x000001CF69F8F160>, '60': <numjuggler.parser.Card object at 0x000001CF69F8F130>, '61': <numjuggler.parser.Card object at 0x000001CF69F8F0D0>, '62': <numjuggler.parser.Card object at 0x000001CF69F8F0A0>, '63': <numjuggler.parser.Card object at 0x000001CF69F8F070>, '64': <numjuggler.parser.Card object at 0x000001CF69F8F040>, '65': <numjuggler.parser.Card object at 0x000001CF699E9940>, '66': <numjuggler.parser.Card object at 0x000001CF699AA340>, '67': <numjuggler.parser.Card object at 0x000001CF69A5F8B0>, '68': <numjuggler.parser.Card object at 0x000001CF6B1AB760>, '69': <numjuggler.parser.Card object at 0x000001CF6B1AB6D0>, '70': <numjuggler.parser.Card object at 0x000001CF6B1ABD60>, '71': <numjuggler.parser.Card object at 0x000001CF6B1ABE50>, '72': <numjuggler.parser.Card object at 0x000001CF6B1ABD90>, '73': <numjuggler.parser.Card object at 0x000001CF6B1ABE80>, '74': <numjuggler.parser.Card object at 0x000001CF6B1ABD00>, '75': <numjuggler.parser.Card object at 0x000001CF6B1ABD30>, '76': <numjuggler.parser.Card object at 0x000001CF6B1AB730>, '77': <numjuggler.parser.Card object at 0x000001CF6B1ABCA0>, '78': <numjuggler.parser.Card object at 0x000001CF6B1ABEE0>, '2': <numjuggler.parser.Card object at 0x000001CF6B1ABF10>, '3': <numjuggler.parser.Card object at 0x000001CF6B1ABFD0>, '4': <numjuggler.parser.Card object at 0x000001CF6B1ABB80>, '5': <numjuggler.parser.Card object at 0x000001CF6B1ABEB0>, '6': <numjuggler.parser.Card object at 0x000001CF6B1AB9A0>, '80': <numjuggler.parser.Card object at 0x000001CF6B1ABE20>, '81': <numjuggler.parser.Card object at 0x000001CF6B1ABDC0>, '82': <numjuggler.parser.Card object at 0x000001CF6B1AB9D0>, '83': <numjuggler.parser.Card object at 0x000001CF6B1ABDF0>, '7': <numjuggler.parser.Card object at 0x000001CF6B1ABFA0>, '8': <numjuggler.parser.Card object at 0x000001CF6B1ABF40>, '9': <numjuggler.parser.Card object at 0x000001CF6B1ABF70>, '10': <numjuggler.parser.Card object at 0x000001CF6B1AB040>, '11': <numjuggler.parser.Card object at 0x000001CF6B1AB070>, '12': <numjuggler.parser.Card object at 0x000001CF6B1AB0A0>, '13': <numjuggler.parser.Card object at 0x000001CF6B1AB0D0>, '14': <numjuggler.parser.Card object at 0x000001CF6B1AB100>, '15': <numjuggler.parser.Card object at 0x000001CF6B1AB190>, '16': <numjuggler.parser.Card object at 0x000001CF6B1AB1C0>, '17': <numjuggler.parser.Card object at 0x000001CF6B1AB1F0>, '18': <numjuggler.parser.Card object at 0x000001CF6B1AB220>, '19': <numjuggler.parser.Card object at 0x000001CF6B1AB2B0>, '20': <numjuggler.parser.Card object at 0x000001CF6B1AB2E0>, '21': <numjuggler.parser.Card object at 0x000001CF6B1AB310>, '22': <numjuggler.parser.Card object at 0x000001CF6B1AB340>, '23': <numjuggler.parser.Card object at 0x000001CF6B1AB130>, '24': <numjuggler.parser.Card object at 0x000001CF6B1AB3D0>, '25': <numjuggler.parser.Card object at 0x000001CF6B1AB400>, '26': <numjuggler.parser.Card object at 0x000001CF6B1AB430>, '27': <numjuggler.parser.Card object at 0x000001CF6B1AB460>, '28': <numjuggler.parser.Card object at 0x000001CF6B1AB490>, '29': <numjuggler.parser.Card object at 0x000001CF6B1AB4C0>, '30': <numjuggler.parser.Card object at 0x000001CF6B1AB4F0>, '31': <numjuggler.parser.Card object at 0x000001CF6B1AB250>, '32': <numjuggler.parser.Card object at 0x000001CF6B1AB370>, '33': <numjuggler.parser.Card object at 0x000001CF6B1AB580>, '34': <numjuggler.parser.Card object at 0x000001CF6B1AB5B0>, '35': <numjuggler.parser.Card object at 0x000001CF6B1AB5E0>, '36': <numjuggler.parser.Card object at 0x000001CF6B1AB160>, '37': <numjuggler.parser.Card object at 0x000001CF6B1AB520>, '38': <numjuggler.parser.Card object at 0x000001CF6B1AB670>, '39': <numjuggler.parser.Card object at 0x000001CF6B1AB3A0>, '40': <numjuggler.parser.Card object at 0x000001CF6B1AB610>, '41': <numjuggler.parser.Card object at 0x000001CF6B1AB700>, '42': <numjuggler.parser.Card object at 0x000001CF6B1AB280>, '43': <numjuggler.parser.Card object at 0x000001CF6B1AB6A0>, '44': <numjuggler.parser.Card object at 0x000001CF6B1AB790>, '45': <numjuggler.parser.Card object at 0x000001CF69D417C0>, '46': <numjuggler.parser.Card object at 0x000001CF6B164760>, '47': <numjuggler.parser.Card object at 0x000001CF6B1AB7C0>, '48': <numjuggler.parser.Card object at 0x000001CF6B1AB7F0>, '84': <numjuggler.parser.Card object at 0x000001CF6B1AB820>, '85': <numjuggler.parser.Card object at 0x000001CF6B1AB850>, '86': <numjuggler.parser.Card object at 0x000001CF6B1AB910>, '87': <numjuggler.parser.Card object at 0x000001CF6B1AB940>, '88': <numjuggler.parser.Card object at 0x000001CF6B1ABA00>, '89': <numjuggler.parser.Card object at 0x000001CF6B1ABA30>, '90': <numjuggler.parser.Card object at 0x000001CF6B1ABA60>, '91': <numjuggler.parser.Card object at 0x000001CF6B1ABA90>, '92': <numjuggler.parser.Card object at 0x000001CF6B1AB640>, '49': <numjuggler.parser.Card object at 0x000001CF6B1AB880>, '50': <numjuggler.parser.Card object at 0x000001CF6B1AB8B0>, '51': <numjuggler.parser.Card object at 0x000001CF6B1AB8E0>, '52': <numjuggler.parser.Card object at 0x000001CF6B1AB550>, '53': <numjuggler.parser.Card object at 0x000001CF6B1ABB20>, '93': <numjuggler.parser.Card object at 0x000001CF6B1ABB50>, '94': <numjuggler.parser.Card object at 0x000001CF6B1ABC10>, '95': <numjuggler.parser.Card object at 0x000001CF6B1ABC40>, '96': <numjuggler.parser.Card object at 0x000001CF6B1ABBE0>, '97': <numjuggler.parser.Card object at 0x000001CF6B1ABBB0>, '98': <numjuggler.parser.Card object at 0x000001CF6B1ABCD0>, '99': <numjuggler.parser.Card object at 0x000001CF6B1AB970>, '100': <numjuggler.parser.Card object at 0x000001CF6B1ABAC0>, '101': <numjuggler.parser.Card object at 0x000001CF6B1ABAF0>, '102': <numjuggler.parser.Card object at 0x000001CF69EABA90>, '103': <numjuggler.parser.Card object at 0x000001CF69EABFD0>, '104': <numjuggler.parser.Card object at 0x000001CF69EABFA0>, '105': <numjuggler.parser.Card object at 0x000001CF69EABF70>, '106': <numjuggler.parser.Card object at 0x000001CF69EABF40>, '107': <numjuggler.parser.Card object at 0x000001CF69EABF10>, '108': <numjuggler.parser.Card object at 0x000001CF69EABEE0>, '109': <numjuggler.parser.Card object at 0x000001CF69EABEB0>, '110': <numjuggler.parser.Card object at 0x000001CF69EABE80>, '111': <numjuggler.parser.Card object at 0x000001CF69EABE50>, '54': <numjuggler.parser.Card object at 0x000001CF69EABE20>, '*55': <numjuggler.parser.Card object at 0x000001CF69EABDF0>, '*56': <numjuggler.parser.Card object at 0x000001CF69EABDC0>}\n",
-      "{'M1': <f4enix.input.materials.Material object at 0x000001CF69D991F0>, 'M2': <f4enix.input.materials.Material object at 0x000001CF69D9E0A0>, 'M3': <f4enix.input.materials.Material object at 0x000001CF6A135AC0>, 'M4': <f4enix.input.materials.Material object at 0x000001CF6A135FD0>, 'M5': <f4enix.input.materials.Material object at 0x000001CF6A135D30>, 'M6': <f4enix.input.materials.Material object at 0x000001CF6A1350D0>, 'M7': <f4enix.input.materials.Material object at 0x000001CF69EC0100>, 'M8': <f4enix.input.materials.Material object at 0x000001CF69EA2730>, 'M9': <f4enix.input.materials.Material object at 0x000001CF69EA2B80>, 'M10': <f4enix.input.materials.Material object at 0x000001CF69AA8220>, 'M11': <f4enix.input.materials.Material object at 0x000001CF69E614F0>, 'M12': <f4enix.input.materials.Material object at 0x000001CF69AB4F40>, 'M13': <f4enix.input.materials.Material object at 0x000001CF69FADDF0>, 'M14': <f4enix.input.materials.Material object at 0x000001CF69FAD8B0>, 'M15': <f4enix.input.materials.Material object at 0x000001CF6A21A700>, 'M16': <f4enix.input.materials.Material object at 0x000001CF699C0220>, 'M17': <f4enix.input.materials.Material object at 0x000001CF69F81E50>, 'M18': <f4enix.input.materials.Material object at 0x000001CF69F81190>, 'M19': <f4enix.input.materials.Material object at 0x000001CF69F81310>, 'M20': <f4enix.input.materials.Material object at 0x000001CF69F81520>, 'M21': <f4enix.input.materials.Material object at 0x000001CF69F818B0>, 'M74': <f4enix.input.materials.Material object at 0x000001CF6A284B80>}\n",
+      "{'1': <numjuggler.parser.Card object at 0x000001C35E3AC390>, '2': <numjuggler.parser.Card object at 0x000001C32234F190>, '3': <numjuggler.parser.Card object at 0x000001C35E3591D0>, '4': <numjuggler.parser.Card object at 0x000001C35E35A290>, '5': <numjuggler.parser.Card object at 0x000001C35E37DE10>, '6': <numjuggler.parser.Card object at 0x000001C35E371010>, '7': <numjuggler.parser.Card object at 0x000001C35E8C76D0>, '8': <numjuggler.parser.Card object at 0x000001C35E8CAF90>, '9': <numjuggler.parser.Card object at 0x000001C300AAD950>, '10': <numjuggler.parser.Card object at 0x000001C322327990>, '11': <numjuggler.parser.Card object at 0x000001C3222DC110>, '12': <numjuggler.parser.Card object at 0x000001C3234825D0>, '13': <numjuggler.parser.Card object at 0x000001C323482750>, '14': <numjuggler.parser.Card object at 0x000001C323482910>, '15': <numjuggler.parser.Card object at 0x000001C323482B90>, '16': <numjuggler.parser.Card object at 0x000001C323483250>, '17': <numjuggler.parser.Card object at 0x000001C3234833D0>, '18': <numjuggler.parser.Card object at 0x000001C323483550>, '19': <numjuggler.parser.Card object at 0x000001C3234836D0>, '20': <numjuggler.parser.Card object at 0x000001C323483850>, '21': <numjuggler.parser.Card object at 0x000001C3234839D0>, '22': <numjuggler.parser.Card object at 0x000001C323483B50>, '23': <numjuggler.parser.Card object at 0x000001C323483CD0>, '24': <numjuggler.parser.Card object at 0x000001C323483E50>, '25': <numjuggler.parser.Card object at 0x000001C323483FD0>, '26': <numjuggler.parser.Card object at 0x000001C32348C190>, '27': <numjuggler.parser.Card object at 0x000001C32348C310>, '28': <numjuggler.parser.Card object at 0x000001C32348C490>, '29': <numjuggler.parser.Card object at 0x000001C32348C610>, '30': <numjuggler.parser.Card object at 0x000001C32348C790>, '31': <numjuggler.parser.Card object at 0x000001C32348C910>, '32': <numjuggler.parser.Card object at 0x000001C32348CA90>, '33': <numjuggler.parser.Card object at 0x000001C32348CC10>, '34': <numjuggler.parser.Card object at 0x000001C32348CD90>, '35': <numjuggler.parser.Card object at 0x000001C32348CF10>, '36': <numjuggler.parser.Card object at 0x000001C32348D090>, '37': <numjuggler.parser.Card object at 0x000001C32348D210>, '38': <numjuggler.parser.Card object at 0x000001C32348D390>, '39': <numjuggler.parser.Card object at 0x000001C32348D510>, '40': <numjuggler.parser.Card object at 0x000001C32348D690>, '41': <numjuggler.parser.Card object at 0x000001C32348D810>, '42': <numjuggler.parser.Card object at 0x000001C32348D990>, '43': <numjuggler.parser.Card object at 0x000001C32348DB10>, '44': <numjuggler.parser.Card object at 0x000001C32348DC90>, '45': <numjuggler.parser.Card object at 0x000001C32348DE10>, '46': <numjuggler.parser.Card object at 0x000001C32348DF90>, '47': <numjuggler.parser.Card object at 0x000001C32348E110>, '48': <numjuggler.parser.Card object at 0x000001C32348E290>, '49': <numjuggler.parser.Card object at 0x000001C32348E410>, '50': <numjuggler.parser.Card object at 0x000001C32348E590>, '51': <numjuggler.parser.Card object at 0x000001C32348E710>, '52': <numjuggler.parser.Card object at 0x000001C32348E890>, '53': <numjuggler.parser.Card object at 0x000001C32348EA10>, '54': <numjuggler.parser.Card object at 0x000001C32348EB90>, '55': <numjuggler.parser.Card object at 0x000001C32348ED10>, '56': <numjuggler.parser.Card object at 0x000001C32348EE90>, '57': <numjuggler.parser.Card object at 0x000001C32348F010>, '58': <numjuggler.parser.Card object at 0x000001C32348F190>, '59': <numjuggler.parser.Card object at 0x000001C32348F310>, '60': <numjuggler.parser.Card object at 0x000001C32348F490>, '61': <numjuggler.parser.Card object at 0x000001C32348F610>, '62': <numjuggler.parser.Card object at 0x000001C32348F790>, '63': <numjuggler.parser.Card object at 0x000001C32348F910>, '64': <numjuggler.parser.Card object at 0x000001C32348FA90>, '65': <numjuggler.parser.Card object at 0x000001C32348FC10>, '66': <numjuggler.parser.Card object at 0x000001C32348FD90>, '67': <numjuggler.parser.Card object at 0x000001C32348FF10>, '68': <numjuggler.parser.Card object at 0x000001C3009FF310>, '69': <numjuggler.parser.Card object at 0x000001C322319A10>, '70': <numjuggler.parser.Card object at 0x000001C323494090>, '71': <numjuggler.parser.Card object at 0x000001C323494490>, '72': <numjuggler.parser.Card object at 0x000001C323494650>, '73': <numjuggler.parser.Card object at 0x000001C3234947D0>, '74': <numjuggler.parser.Card object at 0x000001C323494950>, '75': <numjuggler.parser.Card object at 0x000001C323494AD0>, '76': <numjuggler.parser.Card object at 0x000001C323494C50>, '77': <numjuggler.parser.Card object at 0x000001C323494DD0>, '78': <numjuggler.parser.Card object at 0x000001C323494F50>, '79': <numjuggler.parser.Card object at 0x000001C3234950D0>, '80': <numjuggler.parser.Card object at 0x000001C323495250>, '81': <numjuggler.parser.Card object at 0x000001C3234953D0>, '82': <numjuggler.parser.Card object at 0x000001C323495550>, '83': <numjuggler.parser.Card object at 0x000001C3234956D0>, '84': <numjuggler.parser.Card object at 0x000001C323495810>, '85': <numjuggler.parser.Card object at 0x000001C323495A90>, '86': <numjuggler.parser.Card object at 0x000001C323495C50>, '87': <numjuggler.parser.Card object at 0x000001C323495DD0>, '88': <numjuggler.parser.Card object at 0x000001C323495F50>, '89': <numjuggler.parser.Card object at 0x000001C3234960D0>, '90': <numjuggler.parser.Card object at 0x000001C323496250>, '91': <numjuggler.parser.Card object at 0x000001C3234963D0>, '92': <numjuggler.parser.Card object at 0x000001C323496550>, '93': <numjuggler.parser.Card object at 0x000001C3234966D0>, '94': <numjuggler.parser.Card object at 0x000001C323496850>, '95': <numjuggler.parser.Card object at 0x000001C3234969D0>, '96': <numjuggler.parser.Card object at 0x000001C323496B50>, '97': <numjuggler.parser.Card object at 0x000001C323496CD0>, '98': <numjuggler.parser.Card object at 0x000001C323496E50>, '99': <numjuggler.parser.Card object at 0x000001C323496FD0>, '100': <numjuggler.parser.Card object at 0x000001C323497150>, '101': <numjuggler.parser.Card object at 0x000001C3234972D0>, '102': <numjuggler.parser.Card object at 0x000001C323497450>, '103': <numjuggler.parser.Card object at 0x000001C3234975D0>, '104': <numjuggler.parser.Card object at 0x000001C323497750>, '105': <numjuggler.parser.Card object at 0x000001C323497990>, '106': <numjuggler.parser.Card object at 0x000001C323497B90>}\n",
+      "{'1': <numjuggler.parser.Card object at 0x000001C323497F50>, '60': <numjuggler.parser.Card object at 0x000001C3234A0110>, '61': <numjuggler.parser.Card object at 0x000001C3234A0290>, '62': <numjuggler.parser.Card object at 0x000001C3234A0410>, '63': <numjuggler.parser.Card object at 0x000001C3234A05D0>, '64': <numjuggler.parser.Card object at 0x000001C3234A0750>, '65': <numjuggler.parser.Card object at 0x000001C3234A08D0>, '66': <numjuggler.parser.Card object at 0x000001C3234A0A50>, '67': <numjuggler.parser.Card object at 0x000001C3234A0B90>, '68': <numjuggler.parser.Card object at 0x000001C3234A0D10>, '69': <numjuggler.parser.Card object at 0x000001C3234A0E90>, '70': <numjuggler.parser.Card object at 0x000001C3234A1010>, '71': <numjuggler.parser.Card object at 0x000001C3234A1190>, '72': <numjuggler.parser.Card object at 0x000001C3234A1310>, '73': <numjuggler.parser.Card object at 0x000001C3234A1490>, '74': <numjuggler.parser.Card object at 0x000001C3234A1610>, '75': <numjuggler.parser.Card object at 0x000001C3234A1790>, '76': <numjuggler.parser.Card object at 0x000001C3234A1910>, '77': <numjuggler.parser.Card object at 0x000001C3234A1A90>, '78': <numjuggler.parser.Card object at 0x000001C3234A1C10>, '2': <numjuggler.parser.Card object at 0x000001C3234A1D90>, '3': <numjuggler.parser.Card object at 0x000001C3234A1F90>, '4': <numjuggler.parser.Card object at 0x000001C3234A2110>, '5': <numjuggler.parser.Card object at 0x000001C3234A2310>, '6': <numjuggler.parser.Card object at 0x000001C3234A2510>, '80': <numjuggler.parser.Card object at 0x000001C3234A2710>, '81': <numjuggler.parser.Card object at 0x000001C3234A2910>, '82': <numjuggler.parser.Card object at 0x000001C3234A2B10>, '83': <numjuggler.parser.Card object at 0x000001C3234A2D10>, '7': <numjuggler.parser.Card object at 0x000001C3234A2F10>, '8': <numjuggler.parser.Card object at 0x000001C3234A3110>, '9': <numjuggler.parser.Card object at 0x000001C3234A3310>, '10': <numjuggler.parser.Card object at 0x000001C3234A3510>, '11': <numjuggler.parser.Card object at 0x000001C3234A3710>, '12': <numjuggler.parser.Card object at 0x000001C3234A3910>, '13': <numjuggler.parser.Card object at 0x000001C3234A3B10>, '14': <numjuggler.parser.Card object at 0x000001C3234A3D10>, '15': <numjuggler.parser.Card object at 0x000001C3234A3F10>, '16': <numjuggler.parser.Card object at 0x000001C3234A4150>, '17': <numjuggler.parser.Card object at 0x000001C3234A4350>, '18': <numjuggler.parser.Card object at 0x000001C3234A4550>, '19': <numjuggler.parser.Card object at 0x000001C3234A4750>, '20': <numjuggler.parser.Card object at 0x000001C3234A4950>, '21': <numjuggler.parser.Card object at 0x000001C3234A4B50>, '22': <numjuggler.parser.Card object at 0x000001C3234A4D50>, '23': <numjuggler.parser.Card object at 0x000001C3234A4F50>, '24': <numjuggler.parser.Card object at 0x000001C3234A5150>, '25': <numjuggler.parser.Card object at 0x000001C3234A5350>, '26': <numjuggler.parser.Card object at 0x000001C3234A5550>, '27': <numjuggler.parser.Card object at 0x000001C3234A5750>, '28': <numjuggler.parser.Card object at 0x000001C3234A5950>, '29': <numjuggler.parser.Card object at 0x000001C3234A5B50>, '30': <numjuggler.parser.Card object at 0x000001C3234A5D50>, '31': <numjuggler.parser.Card object at 0x000001C3234A5F50>, '32': <numjuggler.parser.Card object at 0x000001C3234A6150>, '33': <numjuggler.parser.Card object at 0x000001C3234A6350>, '34': <numjuggler.parser.Card object at 0x000001C3234A6550>, '35': <numjuggler.parser.Card object at 0x000001C3234A6750>, '36': <numjuggler.parser.Card object at 0x000001C3234A6950>, '37': <numjuggler.parser.Card object at 0x000001C3234A6B50>, '38': <numjuggler.parser.Card object at 0x000001C3234A6D50>, '39': <numjuggler.parser.Card object at 0x000001C3234A6F50>, '40': <numjuggler.parser.Card object at 0x000001C3234A7150>, '41': <numjuggler.parser.Card object at 0x000001C3234A7350>, '42': <numjuggler.parser.Card object at 0x000001C3234A7550>, '43': <numjuggler.parser.Card object at 0x000001C3234A7750>, '44': <numjuggler.parser.Card object at 0x000001C3234A7950>, '45': <numjuggler.parser.Card object at 0x000001C3234A7B90>, '46': <numjuggler.parser.Card object at 0x000001C3234A7D50>, '47': <numjuggler.parser.Card object at 0x000001C3234A7F50>, '48': <numjuggler.parser.Card object at 0x000001C3234AC1D0>, '84': <numjuggler.parser.Card object at 0x000001C3234AC350>, '85': <numjuggler.parser.Card object at 0x000001C3234AC510>, '86': <numjuggler.parser.Card object at 0x000001C3234AC6D0>, '87': <numjuggler.parser.Card object at 0x000001C3234AC890>, '88': <numjuggler.parser.Card object at 0x000001C3234ACA50>, '89': <numjuggler.parser.Card object at 0x000001C3234ACC10>, '90': <numjuggler.parser.Card object at 0x000001C3234ACDD0>, '91': <numjuggler.parser.Card object at 0x000001C3234ACF90>, '92': <numjuggler.parser.Card object at 0x000001C3234AD190>, '49': <numjuggler.parser.Card object at 0x000001C3234AD350>, '50': <numjuggler.parser.Card object at 0x000001C3234AD550>, '51': <numjuggler.parser.Card object at 0x000001C3234AD750>, '52': <numjuggler.parser.Card object at 0x000001C3234AD950>, '53': <numjuggler.parser.Card object at 0x000001C3234ADB90>, '93': <numjuggler.parser.Card object at 0x000001C3234ADD10>, '94': <numjuggler.parser.Card object at 0x000001C3234ADED0>, '95': <numjuggler.parser.Card object at 0x000001C3234AE090>, '96': <numjuggler.parser.Card object at 0x000001C3234AE250>, '97': <numjuggler.parser.Card object at 0x000001C3234AE410>, '98': <numjuggler.parser.Card object at 0x000001C3234AE5D0>, '99': <numjuggler.parser.Card object at 0x000001C3234AE790>, '100': <numjuggler.parser.Card object at 0x000001C3234AE950>, '101': <numjuggler.parser.Card object at 0x000001C3234AEB10>, '102': <numjuggler.parser.Card object at 0x000001C3234AECD0>, '103': <numjuggler.parser.Card object at 0x000001C3234AEE90>, '104': <numjuggler.parser.Card object at 0x000001C3234AF050>, '105': <numjuggler.parser.Card object at 0x000001C3234AF210>, '106': <numjuggler.parser.Card object at 0x000001C3234AF3D0>, '107': <numjuggler.parser.Card object at 0x000001C3234AF590>, '108': <numjuggler.parser.Card object at 0x000001C3234AF810>, '109': <numjuggler.parser.Card object at 0x000001C3234AF910>, '110': <numjuggler.parser.Card object at 0x000001C3234AFAD0>, '111': <numjuggler.parser.Card object at 0x000001C3234AFCD0>, '54': <numjuggler.parser.Card object at 0x000001C3234AFE90>, '*55': <numjuggler.parser.Card object at 0x000001C3234B00D0>, '*56': <numjuggler.parser.Card object at 0x000001C3234B01D0>}\n",
+      "{'M1': <f4enix.input.materials.Material object at 0x000001C323521850>, 'M2': <f4enix.input.materials.Material object at 0x000001C30018A5D0>, 'M3': <f4enix.input.materials.Material object at 0x000001C323537E10>, 'M4': <f4enix.input.materials.Material object at 0x000001C3235381D0>, 'M5': <f4enix.input.materials.Material object at 0x000001C3235392D0>, 'M6': <f4enix.input.materials.Material object at 0x000001C323538310>, 'M7': <f4enix.input.materials.Material object at 0x000001C323538350>, 'M8': <f4enix.input.materials.Material object at 0x000001C32353BED0>, 'M9': <f4enix.input.materials.Material object at 0x000001C323538150>, 'M10': <f4enix.input.materials.Material object at 0x000001C32353BE90>, 'M11': <f4enix.input.materials.Material object at 0x000001C323542210>, 'M12': <f4enix.input.materials.Material object at 0x000001C323544850>, 'M13': <f4enix.input.materials.Material object at 0x000001C323544810>, 'M14': <f4enix.input.materials.Material object at 0x000001C32355C9D0>, 'M15': <f4enix.input.materials.Material object at 0x000001C323564D10>, 'M16': <f4enix.input.materials.Material object at 0x000001C32355C290>, 'M17': <f4enix.input.materials.Material object at 0x000001C32358EE10>, 'M18': <f4enix.input.materials.Material object at 0x000001C3235946D0>, 'M19': <f4enix.input.materials.Material object at 0x000001C323595B90>, 'M20': <f4enix.input.materials.Material object at 0x000001C323596790>, 'M21': <f4enix.input.materials.Material object at 0x000001C3235969D0>, 'M74': <f4enix.input.materials.Material object at 0x000001C323597210>}\n",
       "{}\n",
-      "{'SDEF': <numjuggler.parser.Card object at 0x000001CF69EAB160>, 'SP1': <numjuggler.parser.Card object at 0x000001CF69EAB310>, 'SI2': <numjuggler.parser.Card object at 0x000001CF69EAB3A0>, 'SP2': <numjuggler.parser.Card object at 0x000001CF69EAB370>, 'SI3': <numjuggler.parser.Card object at 0x000001CF69EAB100>, 'SP3': <numjuggler.parser.Card object at 0x000001CF69EAB190>, 'SI4': <numjuggler.parser.Card object at 0x000001CF69EAB1F0>, 'SP4': <numjuggler.parser.Card object at 0x000001CF69EAB220>, 'MODE': <numjuggler.parser.Card object at 0x000001CF69EAB280>, 'PHYS:N': <numjuggler.parser.Card object at 0x000001CF69EAB490>, 'CUT:N': <numjuggler.parser.Card object at 0x000001CF69EAB430>, 'E4': <numjuggler.parser.Card object at 0x000001CF69EAB040>, 'FC4': <numjuggler.parser.Card object at 0x000001CF69EAB0A0>, 'F4': <numjuggler.parser.Card object at 0x000001CF69EAB0D0>, 'FM4': <numjuggler.parser.Card object at 0x000001CF6A50F370>, 'FC204': <numjuggler.parser.Card object at 0x000001CF6A50FBE0>, 'F204': <numjuggler.parser.Card object at 0x000001CF6A50F400>, 'FM204': <numjuggler.parser.Card object at 0x000001CF6A50F640>, 'FC14': <numjuggler.parser.Card object at 0x000001CF69A386D0>, 'F14': <numjuggler.parser.Card object at 0x000001CF69A385B0>, 'FM14': <numjuggler.parser.Card object at 0x000001CF69A38610>, 'E14': <numjuggler.parser.Card object at 0x000001CF69A38D30>, 'FQ14': <numjuggler.parser.Card object at 0x000001CF69A38B20>, 'FC214': <numjuggler.parser.Card object at 0x000001CF6CBA9730>, 'F214': <numjuggler.parser.Card object at 0x000001CF6CBA99A0>, 'FM214': <numjuggler.parser.Card object at 0x000001CF6CBA98B0>, 'FC6': <numjuggler.parser.Card object at 0x000001CF6CBA9C40>, 'F6': <numjuggler.parser.Card object at 0x000001CF6CBA9790>, 'FM6': <numjuggler.parser.Card object at 0x000001CF6CBA9940>, 'FC16': <numjuggler.parser.Card object at 0x000001CF6CBA9B80>, 'F16': <numjuggler.parser.Card object at 0x000001CF6CBA9BB0>, 'FM16': <numjuggler.parser.Card object at 0x000001CF6CBA9C10>, 'FC26': <numjuggler.parser.Card object at 0x000001CF6CBA9850>, 'F26': <numjuggler.parser.Card object at 0x000001CF6CBA9CA0>, 'FM26': <numjuggler.parser.Card object at 0x000001CF6CBA9E20>, 'FC24': <numjuggler.parser.Card object at 0x000001CF6CBA9A30>, 'F24': <numjuggler.parser.Card object at 0x000001CF6CBA9AC0>, 'FM24': <numjuggler.parser.Card object at 0x000001CF6CBA9D90>, 'FC34': <numjuggler.parser.Card object at 0x000001CF6CBA9EE0>, 'F34': <numjuggler.parser.Card object at 0x000001CF6CBA9D00>, 'FM34': <numjuggler.parser.Card object at 0x000001CF6CBA9CD0>, 'FC44': <numjuggler.parser.Card object at 0x000001CF6CBA9DF0>, 'F44': <numjuggler.parser.Card object at 0x000001CF6CBA9880>, 'FM44': <numjuggler.parser.Card object at 0x000001CF6CBA97C0>, 'FC54': <numjuggler.parser.Card object at 0x000001CF6CBA97F0>, 'F54': <numjuggler.parser.Card object at 0x000001CF6CBA9F40>, 'FM54': <numjuggler.parser.Card object at 0x000001CF6CBA9E50>, 'FC64': <numjuggler.parser.Card object at 0x000001CF6B1CC130>, 'F64': <numjuggler.parser.Card object at 0x000001CF6B1CC4F0>, 'FM64': <numjuggler.parser.Card object at 0x000001CF6B1CC820>, 'FC74': <numjuggler.parser.Card object at 0x000001CF6B1CC460>, 'F74': <numjuggler.parser.Card object at 0x000001CF6B1CC250>, 'FM74': <numjuggler.parser.Card object at 0x000001CF6B1CC040>, 'FC84': <numjuggler.parser.Card object at 0x000001CF6B1CC610>, 'F84': <numjuggler.parser.Card object at 0x000001CF6B1CC760>, 'FM84': <numjuggler.parser.Card object at 0x000001CF6B1CC1F0>, 'FC94': <numjuggler.parser.Card object at 0x000001CF6B1CC0D0>, 'F94': <numjuggler.parser.Card object at 0x000001CF699FC820>, 'FM94': <numjuggler.parser.Card object at 0x000001CF699FCEE0>, 'FC104': <numjuggler.parser.Card object at 0x000001CF699FCA30>, 'F104': <numjuggler.parser.Card object at 0x000001CF699FC2B0>, 'FM104': <numjuggler.parser.Card object at 0x000001CF6B161A90>, 'FC114': <numjuggler.parser.Card object at 0x000001CF6B161220>, 'F114': <numjuggler.parser.Card object at 0x000001CF6B161A00>, 'FM114': <numjuggler.parser.Card object at 0x000001CF6B161A30>, 'FC124': <numjuggler.parser.Card object at 0x000001CF6B1619A0>, 'F124': <numjuggler.parser.Card object at 0x000001CF69A4B5B0>, 'FM124': <numjuggler.parser.Card object at 0x000001CF69A4B6D0>, 'FC134': <numjuggler.parser.Card object at 0x000001CF69A4BF70>, 'F134': <numjuggler.parser.Card object at 0x000001CF69A4B610>, 'FM134': <numjuggler.parser.Card object at 0x000001CF69A4B370>, 'FC144': <numjuggler.parser.Card object at 0x000001CF69A4B970>, 'F144': <numjuggler.parser.Card object at 0x000001CF69E30D00>, 'FM144': <numjuggler.parser.Card object at 0x000001CF69E30F40>, 'FC154': <numjuggler.parser.Card object at 0x000001CF69E30BB0>, 'F154': <numjuggler.parser.Card object at 0x000001CF69E30910>, 'FM154': <numjuggler.parser.Card object at 0x000001CF69E30F10>, 'FC164': <numjuggler.parser.Card object at 0x000001CF69E30B80>, 'F164': <numjuggler.parser.Card object at 0x000001CF69E30100>, 'FM164': <numjuggler.parser.Card object at 0x000001CF69E306A0>, 'FC174': <numjuggler.parser.Card object at 0x000001CF69E302E0>, 'F174': <numjuggler.parser.Card object at 0x000001CF69E30700>, 'E174': <numjuggler.parser.Card object at 0x000001CF69E30370>, 'FM174': <numjuggler.parser.Card object at 0x000001CF69E30C70>, 'FC1004': <numjuggler.parser.Card object at 0x000001CF69E30760>, 'FMESH1004': <numjuggler.parser.Card object at 0x000001CF69E30EE0>, 'FM1004': <numjuggler.parser.Card object at 0x000001CF69E30D60>, 'FC1024': <numjuggler.parser.Card object at 0x000001CF69E30490>, 'FMESH1024': <numjuggler.parser.Card object at 0x000001CF69E30220>, 'FM1024': <numjuggler.parser.Card object at 0x000001CF69E30610>, 'PRINT': <numjuggler.parser.Card object at 0x000001CF69E30580>, 'RAND': <numjuggler.parser.Card object at 0x000001CF69E30940>, 'PRDMP': <numjuggler.parser.Card object at 0x000001CF69E30CA0>, 'NPS': <numjuggler.parser.Card object at 0x000001CF69E30310>}\n"
+      "{'SDEF': <numjuggler.parser.Card object at 0x000001C3234D1250>, 'SP1': <numjuggler.parser.Card object at 0x000001C3234D1490>, 'SI2': <numjuggler.parser.Card object at 0x000001C3234D1790>, 'SP2': <numjuggler.parser.Card object at 0x000001C3234D19D0>, 'SI3': <numjuggler.parser.Card object at 0x000001C3234D1C10>, 'SP3': <numjuggler.parser.Card object at 0x000001C3234D1E50>, 'SI4': <numjuggler.parser.Card object at 0x000001C3234D2090>, 'SP4': <numjuggler.parser.Card object at 0x000001C3234D2390>, 'MODE': <numjuggler.parser.Card object at 0x000001C3234D2690>, 'PHYS:N': <numjuggler.parser.Card object at 0x000001C3234D2990>, 'CUT:N': <numjuggler.parser.Card object at 0x000001C3234D2C10>, 'E4': <numjuggler.parser.Card object at 0x000001C3234D2ED0>, 'FC4': <numjuggler.parser.Card object at 0x000001C3234D31D0>, 'F4': <numjuggler.parser.Card object at 0x000001C3234D3310>, 'FM4': <numjuggler.parser.Card object at 0x000001C3234D35D0>, 'FC204': <numjuggler.parser.Card object at 0x000001C3234D3850>, 'F204': <numjuggler.parser.Card object at 0x000001C3234D3990>, 'FM204': <numjuggler.parser.Card object at 0x000001C3234D3BD0>, 'FC14': <numjuggler.parser.Card object at 0x000001C3234D3E10>, 'F14': <numjuggler.parser.Card object at 0x000001C3234D3C50>, 'FM14': <numjuggler.parser.Card object at 0x000001C3234E41D0>, 'E14': <numjuggler.parser.Card object at 0x000001C3234E4310>, 'FQ14': <numjuggler.parser.Card object at 0x000001C3234E4550>, 'FC214': <numjuggler.parser.Card object at 0x000001C3234E4750>, 'F214': <numjuggler.parser.Card object at 0x000001C3234E48D0>, 'FM214': <numjuggler.parser.Card object at 0x000001C3234E4B50>, 'FC6': <numjuggler.parser.Card object at 0x000001C3234E4D90>, 'F6': <numjuggler.parser.Card object at 0x000001C3234E4F10>, 'FM6': <numjuggler.parser.Card object at 0x000001C3234E5150>, 'FC16': <numjuggler.parser.Card object at 0x000001C3234E53D0>, 'F16': <numjuggler.parser.Card object at 0x000001C3234E55D0>, 'FM16': <numjuggler.parser.Card object at 0x000001C3234E5710>, 'FC26': <numjuggler.parser.Card object at 0x000001C3234E59D0>, 'F26': <numjuggler.parser.Card object at 0x000001C3234E5BD0>, 'FM26': <numjuggler.parser.Card object at 0x000001C3234E5D10>, 'FC24': <numjuggler.parser.Card object at 0x000001C3234E5FD0>, 'F24': <numjuggler.parser.Card object at 0x000001C3234E6290>, 'FM24': <numjuggler.parser.Card object at 0x000001C3234E6590>, 'FC34': <numjuggler.parser.Card object at 0x000001C3234E6750>, 'F34': <numjuggler.parser.Card object at 0x000001C3234E6A50>, 'FM34': <numjuggler.parser.Card object at 0x000001C3234E6D50>, 'FC44': <numjuggler.parser.Card object at 0x000001C3234E6F10>, 'F44': <numjuggler.parser.Card object at 0x000001C3234E7210>, 'FM44': <numjuggler.parser.Card object at 0x000001C3234E7510>, 'FC54': <numjuggler.parser.Card object at 0x000001C3234E76D0>, 'F54': <numjuggler.parser.Card object at 0x000001C3234E79D0>, 'FM54': <numjuggler.parser.Card object at 0x000001C3234E7CD0>, 'FC64': <numjuggler.parser.Card object at 0x000001C3234E7E90>, 'F64': <numjuggler.parser.Card object at 0x000001C3234EC090>, 'FM64': <numjuggler.parser.Card object at 0x000001C3234EC190>, 'FC74': <numjuggler.parser.Card object at 0x000001C3234EC450>, 'F74': <numjuggler.parser.Card object at 0x000001C3234EC610>, 'FM74': <numjuggler.parser.Card object at 0x000001C3234EC710>, 'FC84': <numjuggler.parser.Card object at 0x000001C3234EC9D0>, 'F84': <numjuggler.parser.Card object at 0x000001C3234ECB90>, 'FM84': <numjuggler.parser.Card object at 0x000001C3234ECC90>, 'FC94': <numjuggler.parser.Card object at 0x000001C3234ECF50>, 'F94': <numjuggler.parser.Card object at 0x000001C3234ED110>, 'FM94': <numjuggler.parser.Card object at 0x000001C3234ED210>, 'FC104': <numjuggler.parser.Card object at 0x000001C3234ED4D0>, 'F104': <numjuggler.parser.Card object at 0x000001C3234ED690>, 'FM104': <numjuggler.parser.Card object at 0x000001C3234ED790>, 'FC114': <numjuggler.parser.Card object at 0x000001C3234EDA50>, 'F114': <numjuggler.parser.Card object at 0x000001C3234EDC10>, 'FM114': <numjuggler.parser.Card object at 0x000001C3234EDD10>, 'FC124': <numjuggler.parser.Card object at 0x000001C3234EDFD0>, 'F124': <numjuggler.parser.Card object at 0x000001C3234EE190>, 'FM124': <numjuggler.parser.Card object at 0x000001C3234EE290>, 'FC134': <numjuggler.parser.Card object at 0x000001C3234EE550>, 'F134': <numjuggler.parser.Card object at 0x000001C3234EE710>, 'FM134': <numjuggler.parser.Card object at 0x000001C3234EE810>, 'FC144': <numjuggler.parser.Card object at 0x000001C3234EEA10>, 'F144': <numjuggler.parser.Card object at 0x000001C3234EEC10>, 'FM144': <numjuggler.parser.Card object at 0x000001C3234EEE50>, 'FC154': <numjuggler.parser.Card object at 0x000001C3234EF0D0>, 'F154': <numjuggler.parser.Card object at 0x000001C3234EF250>, 'FM154': <numjuggler.parser.Card object at 0x000001C3234EF450>, 'FC164': <numjuggler.parser.Card object at 0x000001C3234EF6D0>, 'F164': <numjuggler.parser.Card object at 0x000001C3234EF850>, 'FM164': <numjuggler.parser.Card object at 0x000001C3234EFA50>, 'FC174': <numjuggler.parser.Card object at 0x000001C3234EFCD0>, 'F174': <numjuggler.parser.Card object at 0x000001C3234EFE50>, 'E174': <numjuggler.parser.Card object at 0x000001C3234F40D0>, 'FM174': <numjuggler.parser.Card object at 0x000001C3234F4310>, 'FC1004': <numjuggler.parser.Card object at 0x000001C3234F4550>, 'FMESH1004': <numjuggler.parser.Card object at 0x000001C3234F4750>, 'FM1004': <numjuggler.parser.Card object at 0x000001C3234F4950>, 'FC1024': <numjuggler.parser.Card object at 0x000001C3234F4B90>, 'FMESH1024': <numjuggler.parser.Card object at 0x000001C3234F4D90>, 'FM1024': <numjuggler.parser.Card object at 0x000001C3234F4F50>, 'PRINT': <numjuggler.parser.Card object at 0x000001C3234F5110>, 'RAND': <numjuggler.parser.Card object at 0x000001C3234F54D0>, 'PRDMP': <numjuggler.parser.Card object at 0x000001C3234F5750>, 'NPS': <numjuggler.parser.Card object at 0x000001C3234F5910>}\n"
      ]
     }
    ],
@@ -67,18 +67,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'2': <numjuggler.parser.Card object at 0x000001CF6B1641C0>}\n",
-      "{'1': <numjuggler.parser.Card object at 0x000001CF69F8F160>, '2': <numjuggler.parser.Card object at 0x000001CF6B1ABF10>}\n",
-      "{'2': <numjuggler.parser.Card object at 0x000001CF698EF580>, '3': <numjuggler.parser.Card object at 0x000001CF698EF9A0>, '4': <numjuggler.parser.Card object at 0x000001CF698EF340>, '5': <numjuggler.parser.Card object at 0x000001CF698EF880>, '6': <numjuggler.parser.Card object at 0x000001CF698EF520>, '7': <numjuggler.parser.Card object at 0x000001CF698EF460>, '8': <numjuggler.parser.Card object at 0x000001CF698EF1C0>, '9': <numjuggler.parser.Card object at 0x000001CF698EFC40>, '10': <numjuggler.parser.Card object at 0x000001CF69E972B0>, '11': <numjuggler.parser.Card object at 0x000001CF69E97490>, '12': <numjuggler.parser.Card object at 0x000001CF69E97160>, '13': <numjuggler.parser.Card object at 0x000001CF69E971C0>, '14': <numjuggler.parser.Card object at 0x000001CF69E97430>, '15': <numjuggler.parser.Card object at 0x000001CF69E97370>, '16': <numjuggler.parser.Card object at 0x000001CF69E974C0>, '17': <numjuggler.parser.Card object at 0x000001CF69E97790>, '18': <numjuggler.parser.Card object at 0x000001CF69E975B0>, '19': <numjuggler.parser.Card object at 0x000001CF69E976D0>, '20': <numjuggler.parser.Card object at 0x000001CF69E97610>, '21': <numjuggler.parser.Card object at 0x000001CF69E977C0>, '86': <numjuggler.parser.Card object at 0x000001CF69E97820>, '87': <numjuggler.parser.Card object at 0x000001CF69E97910>, '88': <numjuggler.parser.Card object at 0x000001CF69E97A30>, '89': <numjuggler.parser.Card object at 0x000001CF69E97970>, '90': <numjuggler.parser.Card object at 0x000001CF69E97B20>, '91': <numjuggler.parser.Card object at 0x000001CF69E97B80>, '92': <numjuggler.parser.Card object at 0x000001CF69E97C70>, '93': <numjuggler.parser.Card object at 0x000001CF69E97D90>, '94': <numjuggler.parser.Card object at 0x000001CF69E97FA0>, '95': <numjuggler.parser.Card object at 0x000001CF69E97EE0>, '96': <numjuggler.parser.Card object at 0x000001CF69E97E50>, '97': <numjuggler.parser.Card object at 0x000001CF69E9D0D0>, '98': <numjuggler.parser.Card object at 0x000001CF69E9D400>, '99': <numjuggler.parser.Card object at 0x000001CF69E9D1C0>, '100': <numjuggler.parser.Card object at 0x000001CF69E9D280>, '101': <numjuggler.parser.Card object at 0x000001CF69E9D340>, '102': <numjuggler.parser.Card object at 0x000001CF69E9D130>, '103': <numjuggler.parser.Card object at 0x000001CF69E9D430>, '104': <numjuggler.parser.Card object at 0x000001CF69E9D490>, '105': <numjuggler.parser.Card object at 0x000001CF69E9D580>}\n",
-      "{'M2': <f4enix.input.materials.Material object at 0x000001CF69D9E0A0>, 'M3': <f4enix.input.materials.Material object at 0x000001CF6A135AC0>}\n",
-      "{'SDEF': <numjuggler.parser.Card object at 0x000001CF69EAB160>}\n"
+      "{'2': <numjuggler.parser.Card object at 0x000001C32234F190>}\n",
+      "{'1': <numjuggler.parser.Card object at 0x000001C323497F50>, '2': <numjuggler.parser.Card object at 0x000001C3234A1D90>}\n",
+      "{'2': <numjuggler.parser.Card object at 0x000001C322305190>, '3': <numjuggler.parser.Card object at 0x000001C30126CDD0>, '4': <numjuggler.parser.Card object at 0x000001C3022139D0>, '5': <numjuggler.parser.Card object at 0x000001C35E8EDCD0>, '6': <numjuggler.parser.Card object at 0x000001C3234EF590>, '7': <numjuggler.parser.Card object at 0x000001C3009FEA10>, '8': <numjuggler.parser.Card object at 0x000001C3234E6D90>, '9': <numjuggler.parser.Card object at 0x000001C323533D50>, '10': <numjuggler.parser.Card object at 0x000001C323529090>, '11': <numjuggler.parser.Card object at 0x000001C32352C590>, '12': <numjuggler.parser.Card object at 0x000001C3234D03D0>, '13': <numjuggler.parser.Card object at 0x000001C3234D0150>, '14': <numjuggler.parser.Card object at 0x000001C3234D09D0>, '15': <numjuggler.parser.Card object at 0x000001C3234D0910>, '16': <numjuggler.parser.Card object at 0x000001C3234D0F90>, '17': <numjuggler.parser.Card object at 0x000001C3234D16D0>, '18': <numjuggler.parser.Card object at 0x000001C3234D2550>, '19': <numjuggler.parser.Card object at 0x000001C3234D2D90>, '20': <numjuggler.parser.Card object at 0x000001C3234D3D50>, '21': <numjuggler.parser.Card object at 0x000001C3234D1F10>, '86': <numjuggler.parser.Card object at 0x000001C3234B1550>, '87': <numjuggler.parser.Card object at 0x000001C3234B07D0>, '88': <numjuggler.parser.Card object at 0x000001C3234B05D0>, '89': <numjuggler.parser.Card object at 0x000001C3234B0750>, '90': <numjuggler.parser.Card object at 0x000001C3234B0890>, '91': <numjuggler.parser.Card object at 0x000001C3234B0E90>, '92': <numjuggler.parser.Card object at 0x000001C3234B13D0>, '93': <numjuggler.parser.Card object at 0x000001C3234B1790>, '94': <numjuggler.parser.Card object at 0x000001C3234B1FD0>, '95': <numjuggler.parser.Card object at 0x000001C3234B1B90>, '96': <numjuggler.parser.Card object at 0x000001C3234B2650>, '97': <numjuggler.parser.Card object at 0x000001C3234B24D0>, '98': <numjuggler.parser.Card object at 0x000001C3234B2C10>, '99': <numjuggler.parser.Card object at 0x000001C3234B2D50>, '100': <numjuggler.parser.Card object at 0x000001C3234B2FD0>, '101': <numjuggler.parser.Card object at 0x000001C3234B3310>, '102': <numjuggler.parser.Card object at 0x000001C3234B32D0>, '103': <numjuggler.parser.Card object at 0x000001C3234B38D0>, '104': <numjuggler.parser.Card object at 0x000001C3234B3D50>, '105': <numjuggler.parser.Card object at 0x000001C3234B3410>}\n",
+      "{'M2': <f4enix.input.materials.Material object at 0x000001C30018A5D0>, 'M3': <f4enix.input.materials.Material object at 0x000001C323537E10>}\n",
+      "{'SDEF': <numjuggler.parser.Card object at 0x000001C3234D1250>}\n"
      ]
     }
    ],
@@ -109,14 +109,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\bitteal\\AppData\\Local\\Temp\\new_input.i\n"
+      "C:\\Users\\laghida\\AppData\\Local\\Temp\\new_input.i\n"
      ]
     }
    ],
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +170,7 @@
      "output_type": "stream",
      "text": [
       "<class 'numjuggler.parser.Card'>\n",
-      "['_Card__cr', '_Card__d', '_Card__f', '_Card__i', '_Card__m', '_Card__st', '_Card__u', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slotnames__', '__str__', '__subclasshook__', '__weakref__', '_get_value_by_type', '_protect_nums', '_set_value_by_type', 'apply_map', 'card', 'cstrg', 'ctype', 'debug', 'dtype', 'geom_prefix', 'geom_suffix', 'get_d', 'get_f', 'get_geom', 'get_imp', 'get_input', 'get_m', 'get_refcells', 'get_u', 'get_values', 'hidden', 'input', 'lines', 'name', 'pos', 'print_debug', 'remove_fill', 'remove_spaces', 'set_d', 'template', 'values']\n"
+      "['_Card__cr', '_Card__d', '_Card__f', '_Card__i', '_Card__m', '_Card__st', '_Card__u', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slotnames__', '__str__', '__subclasshook__', '__weakref__', '_get_value_by_type', '_protect_nums', '_set_value_by_type', 'apply_map', 'card', 'cstrg', 'ctype', 'debug', 'dtype', 'geom_prefix', 'geom_suffix', 'get_d', 'get_f', 'get_geom', 'get_imp', 'get_input', 'get_m', 'get_refcells', 'get_u', 'get_values', 'hidden', 'input', 'lines', 'name', 'pos', 'print_debug', 'remove_fill', 'remove_spaces', 'set_d', 'template', 'values']\n"
      ]
     },
     {
@@ -185,7 +185,7 @@
        " ('', '#gsu')]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -287,288 +287,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "('Material', 'Submaterial', 'Element')",
-         "rawType": "object",
-         "type": "unknown"
-        },
-        {
-         "name": "Atom Fraction",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "Mass Fraction",
-         "rawType": "float64",
-         "type": "float"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "1e6fcd0f-f6eb-400b-9bde-fd0b12ae0af4",
-       "rows": [
-        [
-         "('M1', 1, 'H')",
-         "0.021629987450000002",
-         "-0.019046369054404072"
-        ],
-        [
-         "('M1', 2, 'C')",
-         "0.018920044",
-         "-0.19852384638279644"
-        ],
-        [
-         "('M1', 3, 'N')",
-         "0.0020599984",
-         "-0.025207149198761606"
-        ],
-        [
-         "('M1', 4, 'O')",
-         "0.0270599558",
-         "-0.3782263969083304"
-        ],
-        [
-         "('M1', 5, 'Mg')",
-         "0.00119",
-         "-0.02526762551470718"
-        ],
-        [
-         "('M1', 5, 'Al')",
-         "0.00393",
-         "-0.09263608297242318"
-        ],
-        [
-         "('M1', 5, 'Si')",
-         "0.00800004",
-         "-0.1962878758158198"
-        ],
-        [
-         "('M1', 6, 'S')",
-         "0.00051",
-         "-0.014286112363120699"
-        ],
-        [
-         "('M1', 6, 'Cu')",
-         "0.00091",
-         "-0.05051854178963683"
-        ],
-        [
-         "('M2', 1, 'Cu')",
-         "0.0829204",
-         "-1.0"
-        ],
-        [
-         "('M3', 1, 'Nb')",
-         "0.0409117",
-         "-0.7013054044967559"
-        ],
-        [
-         "('M3', 2, 'Sn')",
-         "0.013637208999999999",
-         "-0.29869459550324423"
-        ],
-        [
-         "('M4', 1, 'He')",
-         "0.0183643246082",
-         "-1.0"
-        ],
-        [
-         "('M5', 1, 'Pb')",
-         "0.032955761",
-         "-1.0"
-        ],
-        [
-         "('M6', 1, 'B')",
-         "0.1098485",
-         "-0.7826488890810552"
-        ],
-        [
-         "('M6', 2, 'C')",
-         "0.027462144",
-         "-0.2173511109189447"
-        ],
-        [
-         "('M7', 1, 'H')",
-         "0.06685598844",
-         "-0.11189828147140427"
-        ],
-        [
-         "('M7', 2, 'O')",
-         "0.03342803",
-         "-0.8881017185285957"
-        ],
-        [
-         "('M8', 1, 'Ni')",
-         "0.00182368",
-         "-0.02003466964696536"
-        ],
-        [
-         "('M8', 1, 'Cu')",
-         "0.082",
-         "-0.974957268410447"
-        ],
-        [
-         "('M8', 1, 'Be')",
-         "0.00297",
-         "-0.00500806194258743"
-        ],
-        [
-         "('M9', 1, 'Be')",
-         "0.123619",
-         "-1.0"
-        ],
-        [
-         "('M10', 1, 'Cu')",
-         "0.076723",
-         "-0.9199858708463433"
-        ],
-        [
-         "('M10', 2, 'Sn')",
-         "0.0035720034000000004",
-         "-0.08001412915365685"
-        ],
-        [
-         "('M11', 1, 'B')",
-         "4.375456e-06",
-         "-9.99768270325836e-06"
-        ],
-        [
-         "('M11', 2, 'C')",
-         "7.0889518e-05",
-         "-0.00017995365742693698"
-        ],
-        [
-         "('M11', 3, 'N')",
-         "0.000236401503",
-         "-0.0006998342559016584"
-        ],
-        [
-         "('M11', 4, 'O')",
-         "5.8989544e-06",
-         "-1.9947473891475456e-05"
-        ],
-        [
-         "('M11', 4, 'Al')",
-         "0.00052595",
-         "-0.0029993020648270115"
-        ],
-        [
-         "('M11', 4, 'Si')",
-         "0.0007747610000000001",
-         "-0.004598933592031983"
-        ],
-        [
-         "('M11', 4, 'P')",
-         "3.97072e-05",
-         "-0.00025993948678856344"
-        ],
-        [
-         "('M11', 5, 'S')",
-         "1.475257952e-05",
-         "-9.997696886253106e-05"
-        ],
-        [
-         "('M11', 6, 'K')",
-         "6.049259926e-07",
-         "-4.998836513330738e-06"
-        ],
-        [
-         "('M11', 6, 'Ti')",
-         "3.95197e-05",
-         "-0.0003998126787588103"
-        ],
-        [
-         "('M11', 7, 'V')",
-         "3.71430578e-06",
-         "-3.9990618564906404e-05"
-        ],
-        [
-         "('M11', 7, 'Cr')",
-         "0.015571690000000001",
-         "-0.17113425404041901"
-        ],
-        [
-         "('M11', 7, 'Mn')",
-         "0.00146375",
-         "-0.01699609449719344"
-        ],
-        [
-         "('M11', 7, 'Fe')",
-         "0.05457352",
-         "-0.6441581701220173"
-        ],
-        [
-         "('M11', 7, 'Co')",
-         "2.40797e-05",
-         "-0.00029993012607535866"
-        ],
-        [
-         "('M11', 7, 'Ni')",
-         "0.010638439999999999",
-         "-0.1320138359224999"
-        ],
-        [
-         "('M11', 7, 'Cu')",
-         "7.44397e-05",
-         "-0.0009997746800934563"
-        ],
-        [
-         "('M11', 8, 'Zr')",
-         "1.0370802e-06",
-         "-1.99953397446587e-05"
-        ],
-        [
-         "('M11', 8, 'Nb')",
-         "1.0183e-06",
-         "-1.9995408749240243e-05"
-        ],
-        [
-         "('M11', 8, 'Mo')",
-         "0.00123274",
-         "-0.02499428678881784"
-        ],
-        [
-         "('M11', 9, 'Sn')",
-         "7.969524499999999e-07",
-         "-1.999535693221254e-05"
-        ],
-        [
-         "('M11', 9, 'Ta')",
-         "1.30709e-07",
-         "-4.998829292790649e-06"
-        ],
-        [
-         "('M11', 9, 'W')",
-         "2.56984081e-07",
-         "-9.985262105907748e-06"
-        ],
-        [
-         "('M11', 9, 'Pb')",
-         "1.8262302e-07",
-         "-7.99815373252122e-06"
-        ],
-        [
-         "('M11', 9, 'Bi')",
-         "1.81082e-07",
-         "-7.998156055719988e-06"
-        ],
-        [
-         "('M12', 1, 'Ni')",
-         "0.0526997",
-         "-0.6201927186032778"
-        ]
-       ],
-       "shape": {
-        "columns": 2,
-        "rows": 161
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -690,7 +413,7 @@
        "[161 rows x 2 columns]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -709,343 +432,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "('Material', 'Submaterial', 'Element')",
-         "rawType": "object",
-         "type": "unknown"
-        },
-        {
-         "name": "Fraction",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "Sub-Material Fraction",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "Material Fraction",
-         "rawType": "float64",
-         "type": "float"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "d87a5089-f423-4dda-abf8-d84b7145ac18",
-       "rows": [
-        [
-         "('M1', 1, 'H')",
-         "0.021629987450000002",
-         "1.0",
-         "0.25685762809169743"
-        ],
-        [
-         "('M1', 2, 'C')",
-         "0.018920044",
-         "1.0",
-         "0.22467685829519754"
-        ],
-        [
-         "('M1', 3, 'N')",
-         "0.0020599984",
-         "1.0",
-         "0.024462626440252128"
-        ],
-        [
-         "('M1', 4, 'O')",
-         "0.0270599558",
-         "1.0",
-         "0.3213388856152189"
-        ],
-        [
-         "('M1', 5, 'Al')",
-         "0.00393",
-         "0.29954176968972657",
-         "0.04666902746632758"
-        ],
-        [
-         "('M1', 5, 'Mg')",
-         "0.00119",
-         "0.09070094298492994",
-         "0.014131334016521583"
-        ],
-        [
-         "('M1', 5, 'Si')",
-         "0.00800004",
-         "0.6097572873253435",
-         "0.0950010398197759"
-        ],
-        [
-         "('M1', 6, 'Cu')",
-         "0.00091",
-         "0.6408450704225352",
-         "0.010806314247928269"
-        ],
-        [
-         "('M1', 6, 'S')",
-         "0.00051",
-         "0.3591549295774648",
-         "0.006056286007080678"
-        ],
-        [
-         "('M10', 1, 'Cu')",
-         "0.076723",
-         "1.0",
-         "0.9555140015100866"
-        ],
-        [
-         "('M10', 2, 'Sn')",
-         "0.0035720034000000004",
-         "1.0",
-         "0.04448599848991352"
-        ],
-        [
-         "('M11', 1, 'B')",
-         "4.375456e-06",
-         "1.0",
-         "5.129561068550012e-05"
-        ],
-        [
-         "('M11', 2, 'C')",
-         "7.0889518e-05",
-         "1.0",
-         "0.0008310724909611142"
-        ],
-        [
-         "('M11', 3, 'N')",
-         "0.000236401503",
-         "1.0",
-         "0.0027714504415894225"
-        ],
-        [
-         "('M11', 4, 'Al')",
-         "0.00052595",
-         "0.39065832168973214",
-         "0.00616596908757368"
-        ],
-        [
-         "('M11', 4, 'O')",
-         "5.8989544e-06",
-         "0.004381548865154979",
-         "6.9156327558526e-05"
-        ],
-        [
-         "('M11', 4, 'P')",
-         "3.97072e-05",
-         "0.02949319918433032",
-         "0.00046550692604640294"
-        ],
-        [
-         "('M11', 4, 'Si')",
-         "0.0007747610000000001",
-         "0.5754669302607827",
-         "0.00908290213187123"
-        ],
-        [
-         "('M11', 5, 'S')",
-         "1.475257952e-05",
-         "1.0",
-         "0.0001729517050713805"
-        ],
-        [
-         "('M11', 6, 'K')",
-         "6.049259926e-07",
-         "0.015076177724661253",
-         "7.091843275295038e-06"
-        ],
-        [
-         "('M11', 6, 'Ti')",
-         "3.95197e-05",
-         "0.9849238222753388",
-         "0.00046330877184178266"
-        ],
-        [
-         "('M11', 7, 'Co')",
-         "2.40797e-05",
-         "0.0002924081008791407",
-         "0.0002822981002719801"
-        ],
-        [
-         "('M11', 7, 'Cr')",
-         "0.015571690000000001",
-         "0.1890924014991344",
-         "0.18255453784823694"
-        ],
-        [
-         "('M11', 7, 'Cu')",
-         "7.44397e-05",
-         "0.0009039469473046994",
-         "0.0008726930109102739"
-        ],
-        [
-         "('M11', 7, 'Fe')",
-         "0.05457352",
-         "0.6627050727994868",
-         "0.6397920663943036"
-        ],
-        [
-         "('M11', 7, 'Mn')",
-         "0.00146375",
-         "0.01777482101778021",
-         "0.01716025715740275"
-        ],
-        [
-         "('M11', 7, 'Ni')",
-         "0.010638439999999999",
-         "0.12918624553946623",
-         "0.12471963528853948"
-        ],
-        [
-         "('M11', 7, 'V')",
-         "3.71430578e-06",
-         "4.510409594862956e-05",
-         "4.3544623293613935e-05"
-        ],
-        [
-         "('M11', 8, 'Mo')",
-         "0.00123274",
-         "0.998335448744822",
-         "0.014452013942419581"
-        ],
-        [
-         "('M11', 8, 'Nb')",
-         "1.0183e-06",
-         "0.0008246710477934133",
-         "1.1938028941679397e-05"
-        ],
-        [
-         "('M11', 8, 'Zr')",
-         "1.0370802e-06",
-         "0.0008398802073846633",
-         "1.2158198411511988e-05"
-        ],
-        [
-         "('M11', 9, 'Bi')",
-         "1.81082e-07",
-         "0.11695155201323658",
-         "2.1229128516323175e-06"
-        ],
-        [
-         "('M11', 9, 'Pb')",
-         "1.8262302e-07",
-         "0.11794681758730488",
-         "2.1409789827918052e-06"
-        ],
-        [
-         "('M11', 9, 'Sn')",
-         "7.969524499999999e-07",
-         "0.5147106057380154",
-         "9.343063353866544e-06"
-        ],
-        [
-         "('M11', 9, 'Ta')",
-         "1.30709e-07",
-         "0.08441822164598436",
-         "1.5323655356358367e-06"
-        ],
-        [
-         "('M11', 9, 'W')",
-         "2.56984081e-07",
-         "0.16597280301545875",
-         "3.0127500702434277e-06"
-        ],
-        [
-         "('M12', 1, 'Al')",
-         "0.000375",
-         "0.004579513916959613",
-         "0.0044633760538036514"
-        ],
-        [
-         "('M12', 1, 'Cr')",
-         "0.020899700000000004",
-         "0.25522791202741557",
-         "0.24875525469781384"
-        ],
-        [
-         "('M12', 1, 'Fe')",
-         "0.00227001",
-         "0.02772144636436664",
-         "0.02701842206905287"
-        ],
-        [
-         "('M12', 1, 'Mn')",
-         "0.00023",
-         "0.0028087685357352293",
-         "0.0027375373129995733"
-        ],
-        [
-         "('M12', 1, 'Mo')",
-         "0.004750010000000001",
-         "0.05800729840185956",
-         "0.05653621570487436"
-        ],
-        [
-         "('M12', 1, 'Ni')",
-         "0.0526997",
-         "0.6435706921855907",
-         "0.6272495440603635"
-        ],
-        [
-         "('M12', 1, 'Si')",
-         "0.000449996",
-         "0.005495367852203088",
-         "0.005356003655219808"
-        ],
-        [
-         "('M12', 1, 'Ti')",
-         "0.00021200400000000004",
-         "0.002589000715869616",
-         "0.0025233428717615723"
-        ],
-        [
-         "('M12', 2, 'S')",
-         "1.269996e-05",
-         "1.0",
-         "0.00015115919292870458"
-        ],
-        [
-         "('M12', 3, 'C')",
-         "0.00021099969999999998",
-         "0.09962215764242081",
-         "0.0025113893555726782"
-        ],
-        [
-         "('M12', 3, 'Nb')",
-         "0.001907",
-         "0.9003778423575792",
-         "0.022697755025609504"
-        ],
-        [
-         "('M13', 1, 'B')",
-         "2.05644e-06",
-         "1.0",
-         "2.8523675088129415e-05"
-        ],
-        [
-         "('M13', 2, 'C')",
-         "7.0889518e-05",
-         "1.0",
-         "0.000983266994702545"
-        ],
-        [
-         "('M13', 3, 'N')",
-         "0.000111109437",
-         "1.0",
-         "0.0015411339403109182"
-        ]
-       ],
-       "shape": {
-        "columns": 3,
-        "rows": 161
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1198,7 +589,7 @@
        "[161 rows x 3 columns]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1210,343 +601,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "('Material', 'Submaterial', 'Element')",
-         "rawType": "object",
-         "type": "unknown"
-        },
-        {
-         "name": "Fraction",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "Sub-Material Fraction",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "Material Fraction",
-         "rawType": "float64",
-         "type": "float"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "3e639808-0329-4644-a554-afef0b9eddca",
-       "rows": [
-        [
-         "('M1', 1, 'H')",
-         "-0.019046369054404072",
-         "1.0",
-         "0.01904636905440407"
-        ],
-        [
-         "('M1', 2, 'C')",
-         "-0.19852384638279644",
-         "1.0",
-         "0.19852384638279638"
-        ],
-        [
-         "('M1', 3, 'N')",
-         "-0.025207149198761606",
-         "1.0",
-         "0.0252071491987616"
-        ],
-        [
-         "('M1', 4, 'O')",
-         "-0.3782263969083304",
-         "1.0",
-         "0.37822639690833026"
-        ],
-        [
-         "('M1', 5, 'Al')",
-         "-0.09263608297242318",
-         "0.29483947884199696",
-         "0.09263608297242316"
-        ],
-        [
-         "('M1', 5, 'Mg')",
-         "-0.02526762551470718",
-         "0.08042107674769418",
-         "0.025267625514707175"
-        ],
-        [
-         "('M1', 5, 'Si')",
-         "-0.1962878758158198",
-         "0.6247394444103088",
-         "0.19628787581581975"
-        ],
-        [
-         "('M1', 6, 'Cu')",
-         "-0.05051854178963683",
-         "0.7795511364130504",
-         "0.050518541789636814"
-        ],
-        [
-         "('M1', 6, 'S')",
-         "-0.014286112363120697",
-         "0.22044886358694973",
-         "0.014286112363120693"
-        ],
-        [
-         "('M10', 1, 'Cu')",
-         "-0.9199858708463433",
-         "1.0",
-         "0.9199858708463431"
-        ],
-        [
-         "('M10', 2, 'Sn')",
-         "-0.08001412915365685",
-         "1.0",
-         "0.08001412915365684"
-        ],
-        [
-         "('M11', 1, 'B')",
-         "-9.99768270325836e-06",
-         "1.0",
-         "9.997682703258362e-06"
-        ],
-        [
-         "('M11', 2, 'C')",
-         "-0.00017995365742693698",
-         "1.0",
-         "0.000179953657426937"
-        ],
-        [
-         "('M11', 3, 'N')",
-         "-0.0006998342559016584",
-         "1.0",
-         "0.0006998342559016585"
-        ],
-        [
-         "('M11', 4, 'Al')",
-         "-0.0029993020648270115",
-         "0.380712792937454",
-         "0.0029993020648270124"
-        ],
-        [
-         "('M11', 4, 'O')",
-         "-1.9947473891475456e-05",
-         "0.0025320085583672527",
-         "1.994747389147546e-05"
-        ],
-        [
-         "('M11', 4, 'P')",
-         "-0.00025993948678856344",
-         "0.0329951054848856",
-         "0.0002599394867885635"
-        ],
-        [
-         "('M11', 4, 'Si')",
-         "-0.004598933592031983",
-         "0.5837600930192931",
-         "0.004598933592031984"
-        ],
-        [
-         "('M11', 5, 'S')",
-         "-9.997696886253106e-05",
-         "1.0",
-         "9.997696886253109e-05"
-        ],
-        [
-         "('M11', 6, 'K')",
-         "-4.998836513330738e-06",
-         "0.012348553153114207",
-         "4.9988365133307385e-06"
-        ],
-        [
-         "('M11', 6, 'Ti')",
-         "-0.0003998126787588104",
-         "0.9876514468468859",
-         "0.0003998126787588105"
-        ],
-        [
-         "('M11', 7, 'Co')",
-         "-0.00029993012607535866",
-         "0.0003106017660200557",
-         "0.0002999301260753587"
-        ],
-        [
-         "('M11', 7, 'Cr')",
-         "-0.17113425404041901",
-         "0.17722328272593627",
-         "0.17113425404041904"
-        ],
-        [
-         "('M11', 7, 'Cu')",
-         "-0.0009997746800934563",
-         "0.0010353470834108254",
-         "0.0009997746800934565"
-        ],
-        [
-         "('M11', 7, 'Fe')",
-         "-0.6441581701220173",
-         "0.6670775885509945",
-         "0.6441581701220174"
-        ],
-        [
-         "('M11', 7, 'Mn')",
-         "-0.01699609449719344",
-         "0.017600822682765978",
-         "0.016996094497193442"
-        ],
-        [
-         "('M11', 7, 'Ni')",
-         "-0.1320138359224999",
-         "0.1367109436892911",
-         "0.13201383592249993"
-        ],
-        [
-         "('M11', 7, 'V')",
-         "-3.9990618564906404e-05",
-         "4.141350158127659e-05",
-         "3.999061856490641e-05"
-        ],
-        [
-         "('M11', 8, 'Mo')",
-         "-0.024994286788817842",
-         "0.9984025603121841",
-         "0.02499428678881785"
-        ],
-        [
-         "('M11', 8, 'Nb')",
-         "-1.9995408749240243e-05",
-         "0.0007987212221099077",
-         "1.9995408749240246e-05"
-        ],
-        [
-         "('M11', 8, 'Zr')",
-         "-1.99953397446587e-05",
-         "0.0007987184657059555",
-         "1.9995339744658704e-05"
-        ],
-        [
-         "('M11', 9, 'Bi')",
-         "-7.998156055719988e-06",
-         "0.15690116931708747",
-         "7.99815605571999e-06"
-        ],
-        [
-         "('M11', 9, 'Pb')",
-         "-7.99815373252122e-06",
-         "0.15690112374250748",
-         "7.998153732521222e-06"
-        ],
-        [
-         "('M11', 9, 'Sn')",
-         "-1.9995356932212544e-05",
-         "0.39225227186371303",
-         "1.9995356932212547e-05"
-        ],
-        [
-         "('M11', 9, 'Ta')",
-         "-4.998829292790649e-06",
-         "0.09806287296613121",
-         "4.99882929279065e-06"
-        ],
-        [
-         "('M11', 9, 'W')",
-         "-9.985262105907747e-06",
-         "0.19588256211056085",
-         "9.985262105907748e-06"
-        ],
-        [
-         "('M12', 1, 'Al')",
-         "-0.0020280755842672997",
-         "0.002104035872614121",
-         "0.0020280755842673006"
-        ],
-        [
-         "('M12', 1, 'Cr')",
-         "-0.21783058677293962",
-         "0.22598929363297393",
-         "0.2178305867729397"
-        ],
-        [
-         "('M12', 1, 'Fe')",
-         "-0.02541062999291687",
-         "0.02636236906827963",
-         "0.025410629992916878"
-        ],
-        [
-         "('M12', 1, 'Mn')",
-         "-0.0025327200410804685",
-         "0.0026275814683934698",
-         "0.0025327200410804693"
-        ],
-        [
-         "('M12', 1, 'Mo')",
-         "-0.09133579094367007",
-         "0.09475671522789622",
-         "0.0913357909436701"
-        ],
-        [
-         "('M12', 1, 'Ni')",
-         "-0.6201927186032777",
-         "0.6434216446359944",
-         "0.620192718603278"
-        ],
-        [
-         "('M12', 1, 'Si')",
-         "-0.0025332331658965133",
-         "0.002628113811974972",
-         "0.002533233165896514"
-        ],
-        [
-         "('M12', 1, 'Ti')",
-         "-0.0020340617841941204",
-         "0.002110246281873212",
-         "0.0020340617841941213"
-        ],
-        [
-         "('M12', 2, 'S')",
-         "-8.162279812563427e-05",
-         "1.0",
-         "8.16227981256343e-05"
-        ],
-        [
-         "('M12', 3, 'C')",
-         "-0.000507969474008548",
-         "0.014102209115728738",
-         "0.0005079694740085482"
-        ],
-        [
-         "('M12', 3, 'Nb')",
-         "-0.03551259083962274",
-         "0.9858977908842713",
-         "0.03551259083962276"
-        ],
-        [
-         "('M13', 1, 'B')",
-         "-6.207548417984994e-06",
-         "1.0",
-         "6.207548417984998e-06"
-        ],
-        [
-         "('M13', 2, 'C')",
-         "-0.00023773267881429847",
-         "1.0",
-         "0.0002377326788142986"
-        ],
-        [
-         "('M13', 3, 'N')",
-         "-0.00043453435292574276",
-         "1.0",
-         "0.000434534352925743"
-        ]
-       ],
-       "shape": {
-        "columns": 3,
-        "rows": 161
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1699,7 +758,7 @@
        "[161 rows x 3 columns]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1719,288 +778,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "('Material', 'Submaterial', 'Element', 'Isotope')",
-         "rawType": "object",
-         "type": "unknown"
-        },
-        {
-         "name": "Atom Fraction",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "Mass Fraction",
-         "rawType": "float64",
-         "type": "float"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "a3a80c62-48c2-4504-bf7e-dcca59dd829a",
-       "rows": [
-        [
-         "('M1', 1, 'H', 'H-1 [1001]')",
-         "0.25682808944732805",
-         "-0.01904199225447119"
-        ],
-        [
-         "('M1', 1, 'H', 'H-2 [1002]')",
-         "2.9538644369240838e-05",
-         "-4.376799932880233e-06"
-        ],
-        [
-         "('M1', 2, 'C', 'C-12 [6012]')",
-         "0.22227282150222208",
-         "-0.19622409310718747"
-        ],
-        [
-         "('M1', 2, 'C', 'C-13 [6013]')",
-         "0.002404036792975373",
-         "-0.002299753275608962"
-        ],
-        [
-         "('M1', 3, 'N', 'N-14 [7014]')",
-         "0.024373582410849193",
-         "-0.025108887574549803"
-        ],
-        [
-         "('M1', 3, 'N', 'N-15 [7015]')",
-         "8.90440294029289e-05",
-         "-9.826162421180235e-05"
-        ],
-        [
-         "('M1', 4, 'O', 'O-16 [8016]')",
-         "0.32055803084772",
-         "-0.3772014121023883"
-        ],
-        [
-         "('M1', 4, 'O', 'O-17 [8017]')",
-         "0.000122108975987469",
-         "-0.00015270703732339814"
-        ],
-        [
-         "('M1', 4, 'O', 'O-18 [8018]')",
-         "0.0006587457915113458",
-         "-0.0008722777686186963"
-        ],
-        [
-         "('M1', 5, 'Mg', 'Mg-24 [12024]')",
-         "0.011162340739650395",
-         "-0.019696110656811774"
-        ],
-        [
-         "('M1', 5, 'Mg', 'Mg-25 [12025]')",
-         "0.0014131334016521577",
-         "-0.0025975372600699287"
-        ],
-        [
-         "('M1', 5, 'Mg', 'Mg-26 [12026]')",
-         "0.0015558598752190257",
-         "-0.002973977597825478"
-        ],
-        [
-         "('M1', 5, 'Al', 'Al-27 [13027]')",
-         "0.04666902746632757",
-         "-0.09263608297242318"
-        ],
-        [
-         "('M1', 5, 'Si', 'Si-28 [14028]')",
-         "0.08761902093067463",
-         "-0.18033628569036786"
-        ],
-        [
-         "('M1', 5, 'Si', 'Si-29 [14029]')",
-         "0.004449113951789895",
-         "-0.009484274129741269"
-        ],
-        [
-         "('M1', 5, 'Si', 'Si-30 [14030]')",
-         "0.002932904937311344",
-         "-0.0064673159957106775"
-        ],
-        [
-         "('M1', 6, 'S', 'S-32 [16032]')",
-         "0.005754682963928058",
-         "-0.013535580799656383"
-        ],
-        [
-         "('M1', 6, 'S', 'S-33 [16033]')",
-         "4.542214505310507e-05",
-         "-0.00011017689426489573"
-        ],
-        [
-         "('M1', 6, 'S', 'S-34 [16034]')",
-         "0.00025496964089809644",
-         "-0.0006371496821151087"
-        ],
-        [
-         "('M1', 6, 'S', 'S-36 [16036]')",
-         "1.211257201416135e-06",
-         "-3.2049870843098747e-06"
-        ],
-        [
-         "('M1', 6, 'Cu', 'Cu-63 [29063]')",
-         "0.007472566302442395",
-         "-0.03459469091348726"
-        ],
-        [
-         "('M1', 6, 'Cu', 'Cu-65 [29065]')",
-         "0.0033337479454858695",
-         "-0.015923850876149566"
-        ],
-        [
-         "('M2', 1, 'Cu', 'Cu-63 [29063]')",
-         "0.6915005233935195",
-         "-0.6847924829557076"
-        ],
-        [
-         "('M2', 1, 'Cu', 'Cu-65 [29065]')",
-         "0.3084994766064804",
-         "-0.3152075170442924"
-        ],
-        [
-         "('M3', 1, 'Nb', 'Nb-93 [41093]')",
-         "0.7500003345621451",
-         "-0.7013054044967559"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-112 [50112]')",
-         "0.0024249980874961217",
-         "-0.0027312435664545182"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-114 [50114]')",
-         "0.001649996336315361",
-         "-0.0018915487423582945"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-115 [50115]')",
-         "0.0008499986681676805",
-         "-0.0009829946148960955"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-116 [50116]')",
-         "0.03634994789721643",
-         "-0.042402745950871484"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-117 [50117]')",
-         "0.019200017364233626",
-         "-0.022590577311667807"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-118 [50118]')",
-         "0.06054988194172683",
-         "-0.071851071086357"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-119 [50119]')",
-         "0.02147503994992824",
-         "-0.02569970582337214"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-120 [50120]')",
-         "0.08144984164577884",
-         "-0.09829187610828588"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-122 [50122]')",
-         "0.011574970271174443",
-         "-0.014201560939782108"
-        ],
-        [
-         "('M3', 2, 'Sn', 'Sn-124 [50124]')",
-         "0.014474973275817487",
-         "-0.018051271359198904"
-        ],
-        [
-         "('M4', 1, 'He', 'He-3 [2003]')",
-         "1.340000273629012e-06",
-         "-1.0097132272314497e-06"
-        ],
-        [
-         "('M4', 1, 'He', 'He-4 [2004]')",
-         "0.9999986599997264",
-         "-0.9999989902867729"
-        ],
-        [
-         "('M5', 1, 'Pb', 'Pb-204 [82204]')",
-         "0.014000010498923087",
-         "-0.013780848277946003"
-        ],
-        [
-         "('M5', 1, 'Pb', 'Pb-206 [82206]')",
-         "0.24100035195667308",
-         "-0.23955535009324808"
-        ],
-        [
-         "('M5', 1, 'Pb', 'Pb-207 [82207]')",
-         "0.22100020691374714",
-         "-0.22074316602626623"
-        ],
-        [
-         "('M5', 1, 'Pb', 'Pb-208 [82208]')",
-         "0.5239994306306567",
-         "-0.5259206356025397"
-        ],
-        [
-         "('M6', 1, 'B', 'B-10 [5010]')",
-         "0.15823973558816024",
-         "-0.14336364757529588"
-        ],
-        [
-         "('M6', 1, 'B', 'B-11 [5011]')",
-         "0.6417601537139395",
-         "-0.6392852415057594"
-        ],
-        [
-         "('M6', 2, 'C', 'C-12 [6012]')",
-         "0.19786011636505033",
-         "-0.2148332597848731"
-        ],
-        [
-         "('M6', 2, 'C', 'C-13 [6013]')",
-         "0.002139994332850118",
-         "-0.0025178511340716004"
-        ],
-        [
-         "('M7', 1, 'H', 'H-1 [1001]')",
-         "0.6665897621563239",
-         "-0.11187256758389227"
-        ],
-        [
-         "('M7', 1, 'H', 'H-2 [1002]')",
-         "7.666665256937227e-05",
-         "-2.571388751198609e-05"
-        ],
-        [
-         "('M7', 2, 'O', 'O-16 [8016]')",
-         "0.3325235717389149",
-         "-0.8856949905875905"
-        ],
-        [
-         "('M7', 2, 'O', 'O-17 [8017]')",
-         "0.00012666624450834084",
-         "-0.00035856464065553764"
-        ],
-        [
-         "('M7', 2, 'O', 'O-18 [8018]')",
-         "0.0006833332076835355",
-         "-0.0020481633003495746"
-        ]
-       ],
-       "shape": {
-        "columns": 2,
-        "rows": 506
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -2127,7 +909,7 @@
        "[506 rows x 2 columns]"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2146,8 +928,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "F4Enix allows to translate the materials contained into an input to different libraries.\n",
+    "There are different ways to do that:\n",
+    "\n",
+    "- Translate all encountered zaids to a specified library\n",
+    "- Provide a dictionary specifying which zaids needs to be translated to which libraries\n",
+    "- Provide a dictionary specifying which original libraries should be converted to which ones.\n",
+    "\n",
+    "Hereafter are some examples of all these methods"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -2227,6 +1023,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A special mention should go to dosimetry libraries. Often the user does not wish to modify them during the tranlsation (which should happen only for \"transport\" libraries).\n",
+    "For this reason, it is possible to specify a list of libraries that should be ignored by translation operations as an optional argument of the LibManager"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "SubMaterial.from_text() takes 2 positional arguments but 3 were given",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[31], line 9\u001b[0m\n\u001b[0;32m      3\u001b[0m newlibmanager \u001b[38;5;241m=\u001b[39m LibManager(dosimetry_lib\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m21c\u001b[39m\u001b[38;5;124m'\u001b[39m])\n\u001b[0;32m      4\u001b[0m text \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\"\"\u001b[39m\u001b[38;5;124m C Header\u001b[39m\n\u001b[0;32m      5\u001b[0m \u001b[38;5;124m      28058.31c  1\u001b[39m\n\u001b[0;32m      6\u001b[0m \u001b[38;5;124m      28060.31c  1\u001b[39m\n\u001b[0;32m      7\u001b[0m \u001b[38;5;124m      28061.21c  1\u001b[39m\n\u001b[0;32m      8\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[1;32m----> 9\u001b[0m submat \u001b[38;5;241m=\u001b[39m \u001b[43mSubMaterial\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfrom_text\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlibmanager\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     10\u001b[0m submat\u001b[38;5;241m.\u001b[39mtranslate(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m00c\u001b[39m\u001b[38;5;124m'\u001b[39m, newlibmanager)\n\u001b[0;32m     11\u001b[0m submat\u001b[38;5;241m.\u001b[39mto_text()\n",
+      "\u001b[1;31mTypeError\u001b[0m: SubMaterial.from_text() takes 2 positional arguments but 3 were given"
+     ]
+    }
+   ],
+   "source": [
+    "from f4enix.input.materials import SubMaterial\n",
+    "\n",
+    "newlibmanager = LibManager(dosimetry_lib=['21c'])\n",
+    "text = \"\"\" C Header\n",
+    "      28058.31c  1\n",
+    "      28060.31c  1\n",
+    "      28061.21c  1\n",
+    "\"\"\"\n",
+    "submat = SubMaterial.from_text(text)\n",
+    "submat.translate('00c', newlibmanager)\n",
+    "submat.to_text()"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -2236,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -2365,7 +1200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -2418,7 +1253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -2456,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -2518,7 +1353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -2555,7 +1390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -2594,7 +1429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -2621,7 +1456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -2684,209 +1519,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "Tally",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "Particle",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "Description",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "Normalization",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "Other multipliers",
-         "rawType": "object",
-         "type": "unknown"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "ae24e071-697f-4f86-bec2-c6682331c266",
-       "rows": [
-        [
-         "4",
-         "N",
-         "Neutrons Flux (energy binned) [#/cm^2]",
-         "1.222e21",
-         null
-        ],
-        [
-         "6",
-         "NP",
-         "Total Nuclear Heating [W/g]",
-         "1.9577e8",
-         null
-        ],
-        [
-         "14",
-         "P",
-         "Photons Flux (energy binned) [#/cm^2]",
-         "1.222e21",
-         null
-        ],
-        [
-         "16",
-         "N",
-         "Neutron Heating [W/g]",
-         "1.9577e8",
-         null
-        ],
-        [
-         "24",
-         "N",
-         "Fe dpa/FPY",
-         "3.8566e8",
-         "['16', '444']"
-        ],
-        [
-         "26",
-         "P",
-         "Gamma Heating [W/g]",
-         "1.9577e8",
-         null
-        ],
-        [
-         "34",
-         "N",
-         "He in 316SS appm/FPY",
-         "3.8566e10",
-         "['11', '(207:206)']"
-        ],
-        [
-         "44",
-         "N",
-         "H in 316SS appm/FPY",
-         "3.8566e10",
-         "['11', '(203:204:205)']"
-        ],
-        [
-         "54",
-         "N",
-         "T in 316SS appm/FPY",
-         "3.8566e10",
-         "['11', '205']"
-        ],
-        [
-         "64",
-         "N",
-         "Cu dpa/FPY",
-         "3.8566e8",
-         "['2', '444']"
-        ],
-        [
-         "74",
-         "N",
-         "He in CuBeNi appm/FPY",
-         "3.8566e10",
-         "['8', '(207:206)']"
-        ],
-        [
-         "84",
-         "N",
-         "H in CuBeNi appm/FPY",
-         "3.8566e10",
-         "['8', '(203:204:205)']"
-        ],
-        [
-         "94",
-         "N",
-         "T in CuBeNi appm/FPY",
-         "3.8566e10",
-         "['8', '205']"
-        ],
-        [
-         "104",
-         "N",
-         "Ni dpa/FPY",
-         "3.8566e8",
-         "['17', '444']"
-        ],
-        [
-         "114",
-         "N",
-         "He in Inconel appm/FPY",
-         "3.8566e10",
-         "['12', '(207:206)']"
-        ],
-        [
-         "124",
-         "N",
-         "H in Inconel appm/FPY",
-         "3.8566e10",
-         "['12', '(203:204:205)']"
-        ],
-        [
-         "134",
-         "N",
-         "T in Inconel appm/FPY",
-         "3.8566e10",
-         "['12', '205']"
-        ],
-        [
-         "144",
-         "N",
-         "He in Be appm/FPY",
-         "3.8566e10",
-         "['9', '(207:206)']"
-        ],
-        [
-         "154",
-         "N",
-         "H in Be appm/FPY",
-         "3.8566e10",
-         "['9', '(203:204:205)']"
-        ],
-        [
-         "164",
-         "N",
-         "T in Be appm/FPY",
-         "3.8566e10",
-         "['9', '205']"
-        ],
-        [
-         "174",
-         "N",
-         "fast (E>0.1 MeV) fluence at magnet n/cm2/FPY",
-         "3.8566e28",
-         null
-        ],
-        [
-         "204",
-         "N",
-         "Total Neutron Flux [#/cm^2]",
-         "1.222e21",
-         null
-        ],
-        [
-         "214",
-         "P",
-         "Total Photons Flux [#/cm^2]",
-         "1.222e21",
-         null
-        ]
-       ],
-       "shape": {
-        "columns": 4,
-        "rows": 23
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -3139,7 +1776,7 @@
        "214                   <NA>  "
       ]
      },
-     "execution_count": 51,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3151,62 +1788,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "Tally",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "Particle",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "Description",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "Normalization",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "Other multipliers",
-         "rawType": "object",
-         "type": "unknown"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "fc1c0752-0891-41d0-bbc4-cae2e5e3446b",
-       "rows": [
-        [
-         "1004",
-         "N",
-         "Neutron Flux [#/cc/s]",
-         "1.222e21",
-         null
-        ],
-        [
-         "1024",
-         "P",
-         "Photon Flux [#/cc/s]",
-         "1.222e21",
-         null
-        ]
-       ],
-       "shape": {
-        "columns": 4,
-        "rows": 2
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -3265,7 +1851,7 @@
        "1024         P   Photon Flux [#/cc/s]      1.222e21              <NA>"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3291,7 +1877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -3366,7 +1952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -3428,7 +2014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -3447,22 +2033,6 @@
       "*55   pz  1000.0\n",
       "*56   pz -1000.0\n",
       "\n",
-      "c ------------------------------------------------------------------\n",
-      "C           o-------------------------------------------------------o\n",
-      "c           |    H2O                    \n",
-      "c           |                                                       |\n",
-      "c           |                                                       |\n",
-      "c           |    t.a.d. =   1.0028e-001                        M7   |\n",
-      "C           o-------------------------------------------------------o\n",
-      "c     \n",
-      "M7\n",
-      "       1001.31c        6.684830E-2     $ H-1    AB(%) 99.988\n",
-      "       1002.31c        7.688440E-6     $ H-2    AB(%) 0.0115\n",
-      "c         8016.70c 3.34280E-02  $ O        (nat.)\n",
-      "       8016.31c        3.334680E-2     $ O-16   AB(%) 99.757\n",
-      "       8017.31c        1.270260E-5     $ O-17   AB(%) 0.038\n",
-      "       8018.31c        6.852740E-5     $ O-18   AB(%) 0.205\n",
-      "\t plib=84p\n",
       "c ------------------------------------------------------------------\n",
       "c           o-------------------------------------------------------o\n",
       "C           |     S.S. 316L(N)-IG.....100 %                         |   \n",
@@ -3559,6 +2129,22 @@
       "      82207.31c        4.035970E-8     $ Pb-207 AB(%) 22.1\n",
       "      82208.31c        9.569450E-8     $ Pb-208 AB(%) 52.4\n",
       "      83209.31c        1.810820E-7     $ Bi-209 AB(%) 100.0\n",
+      "\t plib=84p\n",
+      "c ------------------------------------------------------------------\n",
+      "C           o-------------------------------------------------------o\n",
+      "c           |    H2O                    \n",
+      "c           |                                                       |\n",
+      "c           |                                                       |\n",
+      "c           |    t.a.d. =   1.0028e-001                        M7   |\n",
+      "C           o-------------------------------------------------------o\n",
+      "c     \n",
+      "M7\n",
+      "       1001.31c        6.684830E-2     $ H-1    AB(%) 99.988\n",
+      "       1002.31c        7.688440E-6     $ H-2    AB(%) 0.0115\n",
+      "c         8016.70c 3.34280E-02  $ O        (nat.)\n",
+      "       8016.31c        3.334680E-2     $ O-16   AB(%) 99.757\n",
+      "       8017.31c        1.270260E-5     $ O-17   AB(%) 0.038\n",
+      "       8018.31c        6.852740E-5     $ O-18   AB(%) 0.205\n",
       "\t plib=84p\n",
       "c\n",
       "c       o-----------------------------------------------------------------o\n",
@@ -3955,7 +2541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -3994,83 +2580,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "cell",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "material",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "density",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "universe",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "filler",
-         "rawType": "float64",
-         "type": "float"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "d833aaf3-3163-41c0-8dad-c9c1a0cc4bc5",
-       "rows": [
-        [
-         "1",
-         "0",
-         "0.0",
-         null,
-         "125.0"
-        ],
-        [
-         "21",
-         "4",
-         "-1.0",
-         "125.0",
-         null
-        ],
-        [
-         "22",
-         "0",
-         "0.0",
-         "125.0",
-         null
-        ],
-        [
-         "99",
-         "0",
-         "0.0",
-         null,
-         null
-        ],
-        [
-         "299",
-         "0",
-         "0.0",
-         "125.0",
-         null
-        ]
-       ],
-       "shape": {
-        "columns": 4,
-        "rows": 5
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -4153,7 +2667,7 @@
        "299          0      0.0     125.0     NaN"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4185,7 +2699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4213,7 +2727,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jade-exp",
+   "display_name": "dev",
    "language": "python",
    "name": "python3"
   },
@@ -4227,7 +2741,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/docs/source/examples/input/jupyters/mcnp_inp.ipynb
+++ b/docs/source/examples/input/jupyters/mcnp_inp.ipynb
@@ -1032,18 +1032,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "SubMaterial.from_text() takes 2 positional arguments but 3 were given",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[31], line 9\u001b[0m\n\u001b[0;32m      3\u001b[0m newlibmanager \u001b[38;5;241m=\u001b[39m LibManager(dosimetry_lib\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m21c\u001b[39m\u001b[38;5;124m'\u001b[39m])\n\u001b[0;32m      4\u001b[0m text \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\"\"\u001b[39m\u001b[38;5;124m C Header\u001b[39m\n\u001b[0;32m      5\u001b[0m \u001b[38;5;124m      28058.31c  1\u001b[39m\n\u001b[0;32m      6\u001b[0m \u001b[38;5;124m      28060.31c  1\u001b[39m\n\u001b[0;32m      7\u001b[0m \u001b[38;5;124m      28061.21c  1\u001b[39m\n\u001b[0;32m      8\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[1;32m----> 9\u001b[0m submat \u001b[38;5;241m=\u001b[39m \u001b[43mSubMaterial\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfrom_text\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlibmanager\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     10\u001b[0m submat\u001b[38;5;241m.\u001b[39mtranslate(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m00c\u001b[39m\u001b[38;5;124m'\u001b[39m, newlibmanager)\n\u001b[0;32m     11\u001b[0m submat\u001b[38;5;241m.\u001b[39mto_text()\n",
-      "\u001b[1;31mTypeError\u001b[0m: SubMaterial.from_text() takes 2 positional arguments but 3 were given"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C Header\n",
+      "      28058.00c        1.000000E+0     $        AB(%)     \n",
+      "      28060.00c        1.000000E+0     $        AB(%)     \n",
+      "      28061.21c        1.000000E+0     $        AB(%)     \n"
      ]
     }
    ],
@@ -1051,14 +1050,15 @@
     "from f4enix.input.materials import SubMaterial\n",
     "\n",
     "newlibmanager = LibManager(dosimetry_lib=['21c'])\n",
-    "text = \"\"\" C Header\n",
-    "      28058.31c  1\n",
-    "      28060.31c  1\n",
-    "      28061.21c  1\n",
-    "\"\"\"\n",
+    "text = [\n",
+    "    'C Headers',\n",
+    "    '      28058.31c  1',\n",
+    "    '      28060.31c  1',\n",
+    "    '      28061.21c  1',\n",
+    "    ]\n",
     "submat = SubMaterial.from_text(text)\n",
     "submat.translate('00c', newlibmanager)\n",
-    "submat.to_text()"
+    "print(submat.to_text())"
    ]
   },
   {

--- a/src/f4enix/input/libmanager.py
+++ b/src/f4enix/input/libmanager.py
@@ -86,7 +86,7 @@ class LibManager:
         defaultlib: str | None = None,
         activationfile: os.PathLike | None = None,
         isotopes_file: os.PathLike | None = None,
-        dosimetry_lib: str | None = None,
+        dosimetry_lib: list[str] | None = None,
     ) -> None:
         """
         Object dealing with all complex operations that involves nuclear data.
@@ -104,8 +104,8 @@ class LibManager:
         isotopes_file : str or path, optional
             path to the isotopes files. If None (default) the file is searched
             in the current directory.
-        dosimetry_lib : str, optional
-            library to be used for dosimetry. The default is None.
+        dosimetry_lib : list[str], optional
+            libraries to be used for dosimetry. The default is None.
             If a library is provided, this would be considered as dosimetry
             library and will be ignored during translation operations.
 
@@ -127,8 +127,8 @@ class LibManager:
             contains the libraries available for each code.
         reactions : dict[str, pd.DataFrame]
             contains the reactions data for the different activation libraries.
-        dosimetry_lib : str | None
-            Library considered as dosimetry. This is ignored
+        dosimetry_lib : list[str]
+            Libraries considered as dosimetry. These are ignored
             during translation operations.
 
         Returns
@@ -136,7 +136,10 @@ class LibManager:
         None.
 
         """
-        self.dosimetry_lib = dosimetry_lib
+        if dosimetry_lib is None:
+            self.dosimetry_lib = []
+        else:
+            self.dosimetry_lib = dosimetry_lib
 
         if xsdir_path is None:
             resources = files(pkg_res)

--- a/src/f4enix/input/libmanager.py
+++ b/src/f4enix/input/libmanager.py
@@ -86,6 +86,7 @@ class LibManager:
         defaultlib: str | None = None,
         activationfile: os.PathLike | None = None,
         isotopes_file: os.PathLike | None = None,
+        dosimetry_lib: str | None = None,
     ) -> None:
         """
         Object dealing with all complex operations that involves nuclear data.
@@ -103,6 +104,10 @@ class LibManager:
         isotopes_file : str or path, optional
             path to the isotopes files. If None (default) the file is searched
             in the current directory.
+        dosimetry_lib : str, optional
+            library to be used for dosimetry. The default is None.
+            If a library is provided, this would be considered as dosimetry
+            library and will be ignored during translation operations.
 
         Attributes
         ----------
@@ -122,12 +127,17 @@ class LibManager:
             contains the libraries available for each code.
         reactions : dict[str, pd.DataFrame]
             contains the reactions data for the different activation libraries.
+        dosimetry_lib : str | None
+            Library considered as dosimetry. This is ignored
+            during translation operations.
 
         Returns
         -------
         None.
 
         """
+        self.dosimetry_lib = dosimetry_lib
+
         if xsdir_path is None:
             resources = files(pkg_res)
             xsdir_file = as_file(resources.joinpath("xsdir.txt"))

--- a/src/f4enix/input/materials.py
+++ b/src/f4enix/input/materials.py
@@ -545,11 +545,7 @@ class SubMaterial:
                 zaid.to_xml(libmanager, material)
 
     def translate(
-        self,
-        newlib: dict | str,
-        lib_manager: LibManager,
-        code: str = "mcnp",
-        update: bool = True,
+        self, newlib: dict | str, lib_manager: LibManager, code: str = "mcnp"
     ) -> None:
         """
         This method implements the translation logic of JADE. All zaids are
@@ -612,19 +608,24 @@ class SubMaterial:
             else:
                 newtag = newlib
 
-            try:
-                translation = lib_manager.convertZaid(
-                    zaid.element + zaid.isotope, newtag, code
-                )
-            except ValueError:
-                # No Available translation was found, ignore zaid
-                # Only video warning, to propagate to the log would be too much
-                print(
-                    "  WARNING: no available translation was found for "
-                    + zaid.name
-                    + ".\n  The zaid has been ignored. "
-                )
-                continue
+            # if it is a dosimetry library, the translation needs to be ignored
+            if zaid.library == lib_manager.dosimetry_lib and zaid.library is not None:
+                # fake a 1to1 translation where the original suffix is retained
+                translation = {zaid.element + zaid.isotope: (zaid.library, 1, 1)}
+            else:
+                try:
+                    translation = lib_manager.convertZaid(
+                        zaid.element + zaid.isotope, newtag, code
+                    )
+                except ValueError:
+                    # No Available translation was found, ignore zaid
+                    # Only video warning, to propagate to the log would be too much
+                    print(
+                        "  WARNING: no available translation was found for "
+                        + zaid.name
+                        + ".\n  The zaid has been ignored. "
+                    )
+                    continue
 
             # Check if it is  atomic or mass fraction
             if float(zaid.fraction) < 0:

--- a/src/f4enix/input/materials.py
+++ b/src/f4enix/input/materials.py
@@ -609,7 +609,7 @@ class SubMaterial:
                 newtag = newlib
 
             # if it is a dosimetry library, the translation needs to be ignored
-            if zaid.library == lib_manager.dosimetry_lib and zaid.library is not None:
+            if zaid.library in lib_manager.dosimetry_lib:
                 # fake a 1to1 translation where the original suffix is retained
                 translation = {zaid.element + zaid.isotope: (zaid.library, 1, 1)}
             else:

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -130,6 +130,14 @@ class TestSubmaterial:
         assert material.zaidList[2].library == "21c"
         assert material.zaidList[0].library == "00c"
 
+    def test_zaid_not_found(self):
+        txt = [
+            "C header",
+            "8001.31c        1     $ O-16   AB(%) 99.757",
+        ]
+        material = SubMaterial.from_text(txt)
+        material.translate("00c", LIBMAN)
+
 
 class TestMaterial:
     def test_natural_expansion(self):

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -17,7 +17,6 @@ XSDIR = as_file(resources.joinpath("xsdir_mcnp6.2"))
 ISOTOPES_FILE = as_file(resources_pkg.joinpath("Isotopes.txt"))
 # Other
 with XSDIR as xsdir_file, ISOTOPES_FILE as isotopes_file:
-
     LIBMAN = LibManager(xsdir_file, isotopes_file=isotopes_file, defaultlib="81c")
 
 # Files
@@ -39,7 +38,6 @@ with as_file(resources.joinpath("activation.i")) as inp:
 
 
 class TestZaid:
-
     tests = [
         {"str": "1001.31c   -2.3", "res": [-2.3, "1", "001", "31c"]},
         {"str": "1001.31c\t-2.3", "res": [-2.3, "1", "001", "31c"]},
@@ -104,7 +102,6 @@ class TestElement:
 
 
 class TestSubmaterial:
-
     def test_get_info(self):
         txt = [
             "C header",
@@ -120,9 +117,21 @@ class TestSubmaterial:
         assert len(df_el.columns) == 2
         assert len(df_zaid.columns) == 3
 
+    def test_dosimetry(self):
+        lm = LibManager(dosimetry_lib="21c")
+        txt = [
+            "C header",
+            "8016.31c        1     $ O-16   AB(%) 99.757",
+            "8017.31c        1     $ O-17   AB(%) 0.038",
+            "8018.21c        1     $ O-18   AB(%) 0.205",
+        ]
+        material = SubMaterial.from_text(txt)
+        material.translate("00c", lm)
+        assert material.zaidList[2].library == "21c"
+        assert material.zaidList[0].library == "00c"
+
 
 class TestMaterial:
-
     def test_natural_expansion(self):
         lm = LibManager()
         material = Material.from_text(["C Header", "M1 1000.31c   -2.3"])


### PR DESCRIPTION
# Description

Dosimetry libraries should not be touched during a translation. Before this PR, this could be obtained giving explicit lists of zaids to be translated. Here, a more convenient method is implemented.

The LibManager object has a new argument that allows to specify a list of  dosimetry libraries (default is None). Then, at the level of single zaid translations, if the original zaid library is aamong the specified dosimetry libraries, the translation for that zaid is ignored.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update

# Testing

Suitable tests have been added to the CI suite

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%