### PR TITLE
147 bug   bad writing of irradiation file when irradiation times are added to the file

### DIFF
--- a/docs/source/examples/input/jupyters/d1suned.ipynb
+++ b/docs/source/examples/input/jupyters/d1suned.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +45,7 @@
        "comment: fake reaction"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +80,7 @@
        "    78195.99c    304    78195900                                  Pt195m"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -130,7 +130,7 @@
        "['26054', '26056', '26057', '26058', '78195']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -207,7 +207,7 @@
        " ['27062900', '8.305e-04', '4.151e-01', '1', 'Co62m']]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -283,7 +283,6 @@
     "    \"24051\": [\"5.982e+00\", \"5.697e+00\"],\n",
     "    \"25054\": [\"5.881e+00\", \"1.829e+00\"],\n",
     "    \"26055\": [\"4.487e+00\", \"6.364e-01\"],\n",
-    "    \"26059\": [\"6.645e+00\", \"5.651e+00\"],\n",
     "    \"27062\": [\"1.336e+00\", \"4.151e-01\"],\n",
     "    \"27062900\": [\"4.151e-01\", \"4.151e-01\"],\n",
     "}\n",
@@ -293,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -310,13 +309,13 @@
     }
    ],
    "source": [
-    "irrad_file.irr_schedules[0].modify_value(3, 4.56)\n",
+    "irrad_file.irr_schedules[0].modify_time_val(3, 4.56)\n",
     "print(irrad_file.get_irrad('24051'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -359,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -398,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -427,7 +426,7 @@
        "    28062.99c    107       26059                          Ni-62 -> Fe-59"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -483,7 +482,7 @@
        " comment: Cr-52 -> Cr-51]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -511,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -557,7 +556,7 @@
        "    78195.98c    304    78195900                                  Pt195m"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -600,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -666,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/examples/input/jupyters/d1suned.ipynb
+++ b/docs/source/examples/input/jupyters/d1suned.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +45,7 @@
        "comment: fake reaction"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -60,27 +60,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "       Parent     MT Daughter                                 Comment\n",
-       "    26054.99c    102    26055                                    Fe55\n",
-       "    26054.99c    103    25054                                    Mn54\n",
-       "    26054.99c    107    24051                                    Cr51\n",
-       "    26056.99c    105    25054                                    Mn54\n",
-       "    26056.99c    103    25056                                    Mn56\n",
-       "    26056.99c     16    26055                                    Fe55\n",
-       "    26057.99c     28    25056                                    Mn56\n",
-       "    26057.99c    104    25056                                    Mn56\n",
-       "    26058.99c    102    26059                                    Fe59\n",
-       "    26058.99c    105    25056                                    Mn56\n",
-       "    78195.99c    304 78195900                                  Pt195m"
+       "       Parent     MT    Daughter                                 Comment\n",
+       "    26054.99c    102       26055                                    Fe55\n",
+       "    26054.99c    103       25054                                    Mn54\n",
+       "    26054.99c    107       24051                                    Cr51\n",
+       "    26056.99c    105       25054                                    Mn54\n",
+       "    26056.99c    103       25056                                    Mn56\n",
+       "    26056.99c     16       26055                                    Fe55\n",
+       "    26057.99c     28       25056                                    Mn56\n",
+       "    26057.99c    104       25056                                    Mn56\n",
+       "    26058.99c    102       26059                                    Fe59\n",
+       "    26058.99c    105       25056                                    Mn56\n",
+       "    78195.99c    304    78195900                                  Pt195m"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,25 +101,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "       Parent     MT Daughter                                 Comment\n",
-      "    26054.98c    102    26055                                    Fe55\n",
-      "    26054.98c    103    25054                                    Mn54\n",
-      "    26054.98c    107    24051                                    Cr51\n",
-      "    26056.98c    105    25054                                    Mn54\n",
-      "    26056.98c    103    25056                                    Mn56\n",
-      "    26056.98c     16    26055                                    Fe55\n",
-      "    26057.98c     28    25056                                    Mn56\n",
-      "    26057.98c    104    25056                                    Mn56\n",
-      "    26058.98c    102    26059                                    Fe59\n",
-      "    26058.98c    105    25056                                    Mn56\n",
-      "    78195.98c    304 78195900                                  Pt195m\n",
+      "       Parent     MT    Daughter                                 Comment\n",
+      "    26054.98c    102       26055                                    Fe55\n",
+      "    26054.98c    103       25054                                    Mn54\n",
+      "    26054.98c    107       24051                                    Cr51\n",
+      "    26056.98c    105       25054                                    Mn54\n",
+      "    26056.98c    103       25056                                    Mn56\n",
+      "    26056.98c     16       26055                                    Fe55\n",
+      "    26057.98c     28       25056                                    Mn56\n",
+      "    26057.98c    104       25056                                    Mn56\n",
+      "    26058.98c    102       26059                                    Fe59\n",
+      "    26058.98c    105       25056                                    Mn56\n",
+      "    78195.98c    304    78195900                                  Pt195m\n",
       "\n",
       "Parent list:\n"
      ]
@@ -130,7 +130,7 @@
        "['26054', '26056', '26057', '26058', '78195']"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -178,7 +178,7 @@
       "\n",
       "Daughter: 26059\n",
       "lambda [1/s]: 1800.0\n",
-      "times: ['4e3', '5e3']\n",
+      "times: ('4e3', '5e3')\n",
       "comment: Fake irr\n",
       "\n"
      ]
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -207,7 +207,7 @@
        " ['27062900', '8.305e-04', '4.151e-01', '1', 'Co62m']]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -238,7 +238,7 @@
       "\n",
       "Daughter: 24051\n",
       "lambda [1/s]: 2.896e-07\n",
-      "times: ['5.982e+00', '5.697e+00']\n",
+      "times: ('5.982e+00', '5.697e+00')\n",
       "comment: Cr51\n",
       "\n",
       "['24051', '25054', '26055', '27062', '27062900']\n"
@@ -251,6 +251,90 @@
     "\n",
     "# auxiliary method to get all daughters\n",
     "print(irrad_file.get_daughters())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also add/remove irradiation schedules and modify them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Daughter: 24051\n",
+      "lambda [1/s]: 2.896e-07\n",
+      "times: ('5.982e+00', '5.697e+00', '5.982e+00', '5.697e+00')\n",
+      "comment: Cr51\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_times = {\n",
+    "    \"24051\": [\"5.982e+00\", \"5.697e+00\"],\n",
+    "    \"25054\": [\"5.881e+00\", \"1.829e+00\"],\n",
+    "    \"26055\": [\"4.487e+00\", \"6.364e-01\"],\n",
+    "    \"26059\": [\"6.645e+00\", \"5.651e+00\"],\n",
+    "    \"27062\": [\"1.336e+00\", \"4.151e-01\"],\n",
+    "    \"27062900\": [\"4.151e-01\", \"4.151e-01\"],\n",
+    "}\n",
+    "irrad_file.add_irradiation_times(new_times)\n",
+    "print(irrad_file.get_irrad('24051'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Daughter: 24051\n",
+      "lambda [1/s]: 2.896e-07\n",
+      "times: ('5.982e+00', '5.697e+00', '5.982e+00', '4.560e+00')\n",
+      "comment: Cr51\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "irrad_file.irr_schedules[0].modify_value(3, 4.56)\n",
+    "print(irrad_file.get_irrad('24051'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Daughter: 24051\n",
+      "lambda [1/s]: 2.896e-07\n",
+      "times: ('5.982e+00', '5.697e+00', '5.982e+00')\n",
+      "comment: Cr51\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "irrad_file.remove_irradiation_time(3)\n",
+    "print(irrad_file.get_irrad('24051'))"
    ]
   },
   {
@@ -275,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -314,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -328,22 +412,22 @@
     {
      "data": {
       "text/plain": [
-       "       Parent     MT Daughter                                 Comment\n",
-       "    24050.99c    102    24051                          Cr-50 -> Cr-51\n",
-       "    24052.99c     16    24051                          Cr-52 -> Cr-51\n",
-       "    25055.99c     16    25054                          Mn-55 -> Mn-54\n",
-       "    26054.99c    102    26055                          Fe-54 -> Fe-55\n",
-       "    26054.99c    103    25054                          Fe-54 -> Mn-54\n",
-       "    26054.99c    107    24051                          Fe-54 -> Cr-51\n",
-       "    26056.99c    105    25054                          Fe-56 -> Mn-54\n",
-       "    26056.99c     16    26055                          Fe-56 -> Fe-55\n",
-       "    26058.99c    102    26059                          Fe-58 -> Fe-59\n",
-       "    27059.99c    103    26059                          Co-59 -> Fe-59\n",
-       "    28058.99c    112    25054                          Ni-58 -> Mn-54\n",
-       "    28062.99c    107    26059                          Ni-62 -> Fe-59"
+       "       Parent     MT    Daughter                                 Comment\n",
+       "    24050.99c    102       24051                          Cr-50 -> Cr-51\n",
+       "    24052.99c     16       24051                          Cr-52 -> Cr-51\n",
+       "    25055.99c     16       25054                          Mn-55 -> Mn-54\n",
+       "    26054.99c    102       26055                          Fe-54 -> Fe-55\n",
+       "    26054.99c    103       25054                          Fe-54 -> Mn-54\n",
+       "    26054.99c    107       24051                          Fe-54 -> Cr-51\n",
+       "    26056.99c    105       25054                          Fe-56 -> Mn-54\n",
+       "    26056.99c     16       26055                          Fe-56 -> Fe-55\n",
+       "    26058.99c    102       26059                          Fe-58 -> Fe-59\n",
+       "    27059.99c    103       26059                          Co-59 -> Fe-59\n",
+       "    28058.99c    112       25054                          Ni-58 -> Mn-54\n",
+       "    28062.99c    107       26059                          Ni-62 -> Fe-59"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -399,7 +483,7 @@
        " comment: Cr-52 -> Cr-51]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -427,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -435,26 +519,23 @@
      "output_type": "stream",
      "text": [
       "before:\n",
-      "0E-5     $        AB(%)     \n",
-      "      74182.99c        6.254000E-7     $        AB(%)     \n",
-      "      74183.21c        3.377160E-7     $        AB(%)     \n",
-      "      74184.21c        7.231040E-7     $        AB(%)     \n",
-      "      74186.99c        6.709480E-7     $        AB(%)     \n",
-      "      82206.21c        4.048800E-7     $        AB(%)     \n",
-      "      82207.21c        3.712800E-7     $        AB(%)     \n",
-      "      82208.21c        8.803200E-7     $        AB(%)     \n",
-      "      83209.21c        1.660000E-6     $        AB(%)     \n",
+      "AB(%)     \n",
+      "      74183.21c        3.377160E-7     $        WEIGHT(%)  AB(%)     \n",
+      "      74184.21c        7.231040E-7     $        WEIGHT(%)  AB(%)     \n",
+      "      74186.99c        6.709480E-7     $        WEIGHT(%)  AB(%)     \n",
+      "      82206.21c        4.048800E-7     $        WEIGHT(%)  AB(%)     \n",
+      "      82207.21c        3.712800E-7     $        WEIGHT(%)  AB(%)     \n",
+      "      82208.21c        8.803200E-7     $        WEIGHT(%)  AB(%)     \n",
+      "      83209.21c        1.660000E-6     $        WEIGHT(%)  AB(%)     \n",
       "\n",
       "after:\n",
-      "1 AB(%) 100.0\n",
-      "      74182.98c        6.254000E-7     $ W-182  AB(%) 26.532\n",
-      "      74183.31c        3.377160E-7     $ W-183  AB(%) 14.327\n",
-      "      74184.31c        7.231040E-7     $ W-184  AB(%) 30.677\n",
-      "      74186.98c        6.709480E-7     $ W-186  AB(%) 28.464\n",
-      "      82206.31c        4.048800E-7     $ Pb-206 AB(%) 24.442\n",
-      "      82207.31c        3.712800E-7     $ Pb-207 AB(%) 22.414\n",
-      "      82208.31c        8.803200E-7     $ Pb-208 AB(%) 53.144\n",
-      "      83209.31c        1.660000E-6     $ Bi-209 AB(%) 100.0\n",
+      "%) 14.327\n",
+      "      74184.31c        7.231040E-7     $ W-184  WEIGHT(%) 0.00096798 AB(%) 30.677\n",
+      "      74186.98c        6.709480E-7     $ W-186  WEIGHT(%) 0.00096798 AB(%) 28.464\n",
+      "      82206.31c        4.048800E-7     $ Pb-206 WEIGHT(%) 0.00076688 AB(%) 24.442\n",
+      "      82207.31c        3.712800E-7     $ Pb-207 WEIGHT(%) 0.00076688 AB(%) 22.414\n",
+      "      82208.31c        8.803200E-7     $ Pb-208 WEIGHT(%) 0.00076688 AB(%) 53.144\n",
+      "      83209.31c        1.660000E-6     $ Bi-209 WEIGHT(%) 0.00077488 AB(%) 100.0\n",
       "\n",
       "reac file:\n"
      ]
@@ -462,21 +543,21 @@
     {
      "data": {
       "text/plain": [
-       "       Parent     MT Daughter                                 Comment\n",
-       "    26054.98c    102    26055                                    Fe55\n",
-       "    26054.98c    103    25054                                    Mn54\n",
-       "    26054.98c    107    24051                                    Cr51\n",
-       "    26056.98c    105    25054                                    Mn54\n",
-       "    26056.98c    103    25056                                    Mn56\n",
-       "    26056.98c     16    26055                                    Fe55\n",
-       "    26057.98c     28    25056                                    Mn56\n",
-       "    26057.98c    104    25056                                    Mn56\n",
-       "    26058.98c    102    26059                                    Fe59\n",
-       "    26058.98c    105    25056                                    Mn56\n",
-       "    78195.98c    304 78195900                                  Pt195m"
+       "       Parent     MT    Daughter                                 Comment\n",
+       "    26054.98c    102       26055                                    Fe55\n",
+       "    26054.98c    103       25054                                    Mn54\n",
+       "    26054.98c    107       24051                                    Cr51\n",
+       "    26056.98c    105       25054                                    Mn54\n",
+       "    26056.98c    103       25056                                    Mn56\n",
+       "    26056.98c     16       26055                                    Fe55\n",
+       "    26057.98c     28       25056                                    Mn56\n",
+       "    26057.98c    104       25056                                    Mn56\n",
+       "    26058.98c    102       26059                                    Fe59\n",
+       "    26058.98c    105       25056                                    Mn56\n",
+       "    78195.98c    304    78195900                                  Pt195m"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -519,43 +600,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "before:\n",
+      "      23050.31c        3.400000E-6     $ V-50   WEIGHT(%) 0.15475 AB(%) 0.25\n",
+      "      23051.31c        1.356600E-3     $ V-51   WEIGHT(%) 0.15475 AB(%) 99.75\n",
+      "      24050.31c        6.343700E-3     $ Cr-50  WEIGHT(%) 16.957 AB(%) 4.345\n",
+      "      24052.31c        1.223320E-1     $ Cr-52  WEIGHT(%) 16.957 AB(%) 83.789\n",
+      "      24053.31c        1.387150E-2     $ Cr-53  WEIGHT(%) 16.957 AB(%) 9.501\n",
+      "      24054.31c        3.452900E-3     $ Cr-54  WEIGHT(%) 16.957 AB(%) 2.365\n",
+      "      25055.31c        1.420000E-2  \n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:root: The Default library 81c was used for zaid 1001\n"
+      "D:\\F4Enix\\src\\f4enix\\input\\libmanager.py:446: UserWarning:  The Default library 81c was used for zaid 1001\n",
+      "  warnings.warn(MSG_DEFLIB.format(self.defaultlib, zaid))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "before:\n",
-      "(%) 5.845\n",
-      "      26056.31c        4.615230E-1     $ Fe-56  AB(%) 91.754\n",
-      "      26057.31c        1.065860E-2     $ Fe-57  AB(%) 2.119\n",
-      "      26058.31c        1.418460E-3     $ Fe-58  AB(%) 0.282\n",
-      "      27059.31c        3.680000E-4     $ Co-59  AB(%) 100.0\n",
-      "      28058.31c        6.167770E-2     $ Ni-58  AB(%) 68.077\n",
-      "      28060.31c        2.375810E-2     $ Ni-60  AB(%) 26.223\n",
-      "      28061.31c        1.032750E-3     $ Ni-61  AB(%) 1.1399\n",
-      "      28062.31c        3.292860E-3     $ Ni-62  AB(%) 3.6345\n",
-      "     \n",
       "\n",
       "after:\n",
-      "(%) 5.845\n",
-      "      26056.99c        4.615230E-1     $ Fe-56  AB(%) 91.754\n",
-      "      26057.99c        1.065860E-2     $ Fe-57  AB(%) 2.119\n",
-      "      26058.99c        1.418460E-3     $ Fe-58  AB(%) 0.282\n",
-      "      27059.00c        3.680000E-4     $ Co-59  AB(%) 100.0\n",
-      "      28058.00c        6.167770E-2     $ Ni-58  AB(%) 68.077\n",
-      "      28060.00c        2.375810E-2     $ Ni-60  AB(%) 26.223\n",
-      "      28061.00c        1.032750E-3     $ Ni-61  AB(%) 1.1399\n",
-      "      28062.00c        3.292860E-3     $ Ni-62  AB(%) 3.6345\n",
-      "     \n"
+      "      23050.00c        3.400000E-6     $ V-50   WEIGHT(%) 0.15475 AB(%) 0.25\n",
+      "      23051.00c        1.356600E-3     $ V-51   WEIGHT(%) 0.15475 AB(%) 99.75\n",
+      "      24050.00c        6.343700E-3     $ Cr-50  WEIGHT(%) 16.957 AB(%) 4.345\n",
+      "      24052.00c        1.223320E-1     $ Cr-52  WEIGHT(%) 16.957 AB(%) 83.789\n",
+      "      24053.00c        1.387150E-2     $ Cr-53  WEIGHT(%) 16.957 AB(%) 9.501\n",
+      "      24054.00c        3.452900E-3     $ Cr-54  WEIGHT(%) 16.957 AB(%) 2.365\n",
+      "      25055.00c        1.420000E-2  \n"
      ]
     }
    ],
@@ -584,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -598,12 +680,9 @@
       "         26058    0\n",
       "         78195    0\n",
       "\n",
-      "c\n",
-      "C ---------------- Dose Calculation --------------------------------------------\n",
-      "C    tally  *    ICF           *      DF        *   Sv/pSv       *     s/h    \n",
-      "C [p/cm^2/#]* 1.0714e17 [#/s]) * [pSv/(p/cm^2)] * 1e-12 [Sv/pSv] * 3600 [s/h] \n",
-      "C ------------------------------------------------------------------------------\n",
-      "F124:p 10 11 12 13\n",
+      "DF124 LOG  0.0485 0.1254 0.205 0.2999 0.3381 0.3572 0.378 0.4066 0.4399\n",
+      "          0.5172 0.7523 1.0041 1.5083 1.9958 2.4657 2.9082 3.7269 4.4834\n",
+      "          7.4896 12.0153 15.9873 19.9191 23.76\n",
       "FU124 0\n",
       "         -26054\n",
       "\n"
@@ -626,7 +705,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pipenv",
+   "display_name": "jade",
    "language": "python",
    "name": "python3"
   },
@@ -640,7 +719,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/src/f4enix/input/d1suned.py
+++ b/src/f4enix/input/d1suned.py
@@ -310,7 +310,7 @@ class IrradiationFile:
         for irradiation in self.irr_schedules:
             if irradiation.daughter in times_dict:
                 # Add the new times to the existing ones
-                irradiation.times.extend(times_dict[irradiation.daughter])
+                irradiation._times.extend(times_dict[irradiation.daughter])
 
         # Ensure all times lists have the same length
         max_length = max(len(irradiation.times) for irradiation in self.irr_schedules)
@@ -347,7 +347,7 @@ class IrradiationFile:
                     f"Index {index} is out of range for daughter {irradiation.daughter}."
                 )
             # Remove the time correction factor at the specified index
-            irradiation.times.pop(index)
+            irradiation._times.pop(index)
 
         # Update the number of schedules (nsc) to reflect the new maximum length
         self.nsc = (
@@ -402,18 +402,9 @@ class Irradiation:
         self.comment = comment
 
     @property
-    def times(self) -> list[str]:
-        """Get the time correction factors."""
-        return self._times
-
-    @times.setter
-    def times(self, value: list[str]) -> None:
-        """Set the time correction factors."""
-        if not isinstance(value, list):
-            raise TypeError("times must be a list of strings")
-        if not all(isinstance(t, str) for t in value):
-            raise ValueError("All elements in times must be strings")
-        self._times = value
+    def times(self) -> tuple[str, ...]:
+        """Get the time correction factors as an immutable tuple."""
+        return tuple(self._times)
 
     def __eq__(self, other) -> bool:
         """
@@ -437,6 +428,28 @@ class Irradiation:
             return condition
         else:
             return False
+
+    def modify_value(self, index: int, new_value: float) -> None:
+        """
+        Modify a value in the times list at the specified index.
+
+        Parameters
+        ----------
+        index : int
+            The index of the value to be modified.
+        new_value : float
+            The new value to be assigned, which will be converted to a string.
+
+        Raises
+        ------
+        IndexError
+            If the provided index is out of range for the times list.
+        """
+        if index < 0 or index >= len(self._times):
+            raise IndexError(f"Index {index} is out of range for the times list.")
+
+        # Convert the new value to a string and assign it to the specified index
+        self._times[index] = f"{new_value:.3e}"  # Format as scientific notation
 
     @classmethod
     def from_text(cls, text: str, nsc: int) -> Irradiation:

--- a/src/f4enix/input/d1suned.py
+++ b/src/f4enix/input/d1suned.py
@@ -207,7 +207,7 @@ class IrradiationFile:
 
         return cls(nsc, irr_schedules, header=header)
 
-    def write(self, path: os.PathLike) -> None:
+    def write(self, path: os.PathLike, format: bool) -> None:
         """
         Write the D1S irradiation file
 
@@ -216,6 +216,9 @@ class IrradiationFile:
         path : os.PathLike
             output path where to save the file (only directory). self.name will
             be used as output file name
+        format : bool
+            if True, the file will be formatted using the formatting
+            attributes. If False, the file will be written as it is.
 
         Returns
         -------
@@ -240,7 +243,14 @@ class IrradiationFile:
             # write schedules
             for schedule in self.irr_schedules:
                 args = schedule._get_format_args()
-                outfile.write(self._irrformat.format(*args) + "\n")
+                if (format):
+                    outfile.write(self._irrformat.format(*args) + "\n")
+                else:
+                    # write the unformatted text
+                    fmt = ""
+                    for s in args:
+                        fmt += "{:<" + str(len(str(s)) + 1) + "}"
+                    outfile.write(fmt.format(*args) + "\n")
 
         logging.info("Irradiation file written at {}".format(outfile))
 

--- a/tests/d1suned_test.py
+++ b/tests/d1suned_test.py
@@ -123,7 +123,7 @@ class TestIrradiationFile:
             irrfile.add_irradiation_times(invalid_key_times)
 
         # Test for ValueError when lists of different lengths are provided
-        new_times = {
+        extra_times = {
             "24051": ["5.982e+00", "5.697e+00"],
             "25054": ["5.881e+00", "1.829e+00"],
             "26055": ["4.487e+00", "6.364e-01"],
@@ -135,7 +135,7 @@ class TestIrradiationFile:
             ValueError,
             match="All input time correction factor lists in `times_dict` must have the same length.",
         ):
-            irrfile.add_irradiation_times(new_times)
+            irrfile.add_irradiation_times(extra_times)
 
         new_times = {
             "24051": ["5.982e+00", "5.697e+00"],

--- a/tests/d1suned_test.py
+++ b/tests/d1suned_test.py
@@ -94,6 +94,34 @@ class TestIrradiationFile:
         assert irrfile.irr_schedules[0].daughter == "24051"
         assert irrfile.irr_schedules[1].daughter == "26055"
 
+    def test_multiple_irradiations(self, tmpdir):
+        """
+        Test multiple irradiation lines
+        """
+        with as_file(RESOURCES.joinpath("irr_test")) as inp:
+            irrfile = IrradiationFile.from_text(inp)
+
+        new_times = {
+            "24051": ["5.982e+00", "5.697e+00"],
+            "25054": ["5.881e+00", "1.829e+00"],
+            "26055": ["4.487e+00", "6.364e-01"],
+            "26059": ["6.645e+00", "5.651e+00"],
+            "27062": ["1.336e+00", "4.151e-01"],
+            "27062900": ["4.151e-01", "4.151e-01"],
+        }
+        irrfile.add_irradiation_times(new_times)
+
+        assert irrfile.nsc == 4
+        irrfile.write(tmpdir)
+
+        new_irrfile_path = os.path.join(tmpdir, "irrad")
+        new_irrfile = IrradiationFile.from_text(new_irrfile_path)
+        assert new_irrfile.nsc == 4
+        assert new_irrfile.irr_schedules[0].times[-1] == "5.697e+00"
+        new_irrfile.remove_irradiation_time(3)
+        assert new_irrfile.nsc == 3
+        assert new_irrfile.irr_schedules[0].times[-1] == "5.982e+00"
+
 
 class TestIrradiation:
 

--- a/tests/d1suned_test.py
+++ b/tests/d1suned_test.py
@@ -121,6 +121,8 @@ class TestIrradiationFile:
         new_irrfile.remove_irradiation_time(3)
         assert new_irrfile.nsc == 3
         assert new_irrfile.irr_schedules[0].times[-1] == "5.982e+00"
+        irrfile.irr_schedules[0].modify_value(3, 4.56)
+        assert float(irrfile.irr_schedules[0].times[3]) == 4.56
 
 
 class TestIrradiation:


### PR DESCRIPTION
# Description
The times attribute of the irradiation object (D1S UNED files parser) was set as property, and the times can be changed only with the methods:
- add_irradiation_times
- remove_irradiation_times
- modify_value of Irradiation class

Fixes #147 

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   test_multiple_irradiations


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%