### PR TITLE
rstore export of tansf and data cards plus improve in write performance

### DIFF
--- a/src/f4enix/input/MCNPinput.py
+++ b/src/f4enix/input/MCNPinput.py
@@ -418,6 +418,14 @@ class Input:
             for cell in extracted_inp._model.cells():
                 cell.remove_param("u")
 
+        # Re-assign old datacards and transformations
+        for tr_card in extracted_inp._model.transforms():
+            extracted_inp._model.remove_transform(tr_card.id)
+        for tr_card in self._model.transforms():
+            extracted_inp._model.add_transform(tr_card.text)
+        for _, card in self.other_data.items():
+            extracted_inp._model.add_data_card(card.text)
+
         return extracted_inp
 
     def extract_universe(

--- a/src/f4enix/input/materials.py
+++ b/src/f4enix/input/materials.py
@@ -32,7 +32,6 @@ import logging
 import os
 import re
 import sys
-import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 from contextlib import contextmanager
 from decimal import Decimal
@@ -206,21 +205,17 @@ class Element:
             collapsed list of zaids composing the element.
 
         """
-        zaids = {}
+        new_zaids: dict[str, Zaid] = {}
         for zaid in zaidList:
             # If already in dic sum the fractions
-            if zaid.name in zaids.keys():
-                zaids[zaid.name] = zaids[zaid.name] + zaid.fraction
+            if zaid.name in new_zaids:
+                new_zaids[zaid.name].fraction += zaid.fraction
             else:
-                zaids[zaid.name] = zaid.fraction
+                new_zaids[zaid.name] = zaid
 
-        zaidList = []
-        for name, fraction in zaids.items():
-            zaidList.append(Zaid.from_string(name + " " + str(fraction)))
-
-        self.Z = zaid.element
-        self.name = zaid.nuclide.element
-        self.zaids = zaidList
+        self.Z = zaidList[0].element
+        self.name = zaidList[0].nuclide.element
+        self.zaids = list(new_zaids.values())
 
     def _get_abundances(self) -> dict[str, float]:
         """
@@ -523,7 +518,7 @@ class Material:
 
         """
         # get_info() uses inplace=False internally, so no copy needed here
-        df = self.get_info()
+        elem_mass_fractions = self._compute_elem_mass_fractions()
 
         if self.header is not None:
             text = self.header + "\n"
@@ -534,9 +529,7 @@ class Material:
 
         for elem in self.elements:
             abundances = elem._get_abundances()
-            elem_mass_fraction = (
-                df.groupby("Element")["Element Mass Fraction"].mean().loc[elem.name]
-            )
+            elem_mass_fraction = elem_mass_fractions[elem.name]
             for zaid in elem.zaids:
                 text = (
                     text
@@ -749,15 +742,37 @@ class Material:
             new_zaids = []
             for zaid in self.zaids:
                 atom_mass = lib_manager.get_zaid_mass(zaid)
-                newz = copy.deepcopy(zaid)
                 if ftype == "atom":
-                    newz.fraction = (-1 * zaid.fraction / atom_mass) / norm
+                    new_frac = (-1 * zaid.fraction / atom_mass) / norm
                 else:
-                    newz.fraction = (-1 * zaid.fraction * atom_mass) / norm
-                new_zaids.append(newz)
-            mat = copy.deepcopy(self)
-            mat.zaids = new_zaids
-            return mat
+                    new_frac = (-1 * zaid.fraction * atom_mass) / norm
+                new_zaids.append(Zaid(new_frac, zaid.nuclide))
+            return Material(
+                self.name,
+                new_zaids,
+                header=self.header,
+                additional_keys=list(self.additional_keys),
+                mx_cards=list(self.mx_cards),
+            )
+
+    def _compute_elem_mass_fractions(self) -> dict[str, float]:
+        """Compute element mass fractions directly, without DataFrames or deepcopy."""
+        totf = self.get_tot_fraction()
+        elem_weights: dict[str, float] = {}
+        if totf < 0:
+            # already mass fractions (negative) — normalize by total
+            for elem in self.elements:
+                elem_weights[elem.name] = elem.get_fraction() / totf
+        else:
+            # atom fractions — weight each zaid by atomic mass
+            total = 0.0
+            for elem in self.elements:
+                w = sum(z.fraction * LM.get_zaid_mass(z) for z in elem.zaids)
+                elem_weights[elem.name] = w
+                total += w
+            for name in elem_weights:
+                elem_weights[name] /= total
+        return elem_weights
 
     def _get_info_df(self) -> pd.DataFrame:
         """

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -245,11 +245,11 @@ class TestInput:
     #     assert False
 
     def test_extract_cells(self, tmpdir):
-        newinput = deepcopy(self.testInput)
+        full = deepcopy(self.testInput)
         cells = [23, 24, 25, 31]
         outfile = tmpdir.mkdir("sub").join("extract.i")
         renumber_offsets = {"cells": 1}
-        newinput = newinput.extract_cells(cells, renumber_offsets=renumber_offsets)
+        newinput = full.extract_cells(cells, renumber_offsets=renumber_offsets)
         newinput.write(outfile)
         # re-read
         inp2 = Input.from_input(outfile)
@@ -257,6 +257,11 @@ class TestInput:
         assert len(inp2.surfs) == 10
         # assert len(inp2.mat_section) == 3  entire mat section is copied now
         assert sorted(inp2.cells.keys()) == ["16", "24", "25", "26", "32"]
+        # verify that the number of transformations materials and datacards is the
+        # same as in the original input
+        assert len(inp2.transformations) == len(full.transformations)
+        assert len(inp2.mat_section) == len(full.mat_section)
+        assert len(inp2.other_data) == len(full.other_data)
 
         with as_file(RESOURCES_INP.joinpath("test_1.i")) as FILE:
             mcnp_input = Input.from_input(FILE)

--- a/tests/resources/input/test.i
+++ b/tests/resources/input/test.i
@@ -2046,3 +2046,4 @@ rand gen=1 seed=19073486328213 $ change random number seed (default ends in 5)
 c 
 c nps 50e3             $ number of particles
 prdmp j 5e3 1 1 $ write mctal,save only the last dump 
+TR100  1 1 1


### PR DESCRIPTION
# Description

extract_cells() and every derived method now include all datacards in the original model (as before migjorn implementation) + some performance improvement in the mat_section.to_text() function. This allows to write inputs in a comparable speed with vanilla migjorn.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extracted MCNP inputs now retain coordinate transformations and other non-material data cards from the source input.
  * Duplicate material nuclides are consolidated while preserving their combined fractions.
  * Material fraction calculations and material switching now produce more consistent results.
* **Tests**
  * Expanded coverage verifies that extracted inputs preserve transformations, materials, and data cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->