### PR TITLE
Add helper for fispact input

### DIFF
--- a/docs/source/examples/examples_idx.rst
+++ b/docs/source/examples/examples_idx.rst
@@ -20,6 +20,7 @@ Pre-Processing
     input/jupyters/e_lite
     input/jupyters/ww
     input/jupyters/ace
+    input/jupyters/fispact_inp
 
 
 .. _post_jupyters:

--- a/docs/source/examples/input/jupyters/fispact_inp.ipynb
+++ b/docs/source/examples/input/jupyters/fispact_inp.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1e92024",
+   "metadata": {},
+   "source": [
+    "# Fispact Input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e274ad36",
+   "metadata": {},
+   "source": [
+    "f4enix deals with fispact inputs and outputs through the `pypact` package. A light-weight wrapper of `pypact.InputData` class is available in f4enix which allows to more easily integrate it with f4enix `Irradiation` and `Material` classes.\n",
+    "\n",
+    "The description of `Irradiation` and `Material` classes are out of scope of this section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a21a91de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from f4enix.input.materials import Material\n",
+    "from f4enix.input.libmanager import LibManager\n",
+    "from f4enix.core.irradiation import IrradiationScenario, Pulse\n",
+    "\n",
+    "material = Material.from_zaids(\n",
+    "    [('Fe', 0.5), ('C', 0.5)],\n",
+    "    LibManager(),\n",
+    "    lib=\"31c\",\n",
+    ")\n",
+    "\n",
+    "pulse_1 = Pulse(time=10, intensity=1.0)\n",
+    "pulse_2 = Pulse(time=20, intensity=2.0)\n",
+    "cooling = Pulse(time=30, intensity=0.0)\n",
+    "\n",
+    "irrad_scenario = IrradiationScenario(\n",
+    "    pulses=[pulse_1, pulse_2],\n",
+    "    cooling_times=[cooling],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78812ef6",
+   "metadata": {},
+   "source": [
+    "f4enix `FispactInp` object has only one attribute, which is the `pypact.InputData` that it wraps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f1045cf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pypact.input.inputdata.InputData at 0x18368592360>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from f4enix.input.fispact_inp import FispactInp\n",
+    "\n",
+    "fisp = FispactInp()\n",
+    "fisp.inp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caa92649",
+   "metadata": {},
+   "source": [
+    "Convenience methods are defined on the wrapper to help insert materials and irradiation scenarios\n",
+    "using native f4enix objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f22bff59",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<< CONTROL PHASE >>\n",
+      "<< the minimum cross section (barns) for inclusion in pathways analysis >>\n",
+      "XSTHRESHOLD 1e-12\n",
+      "<< end control >>\n",
+      "FISPACT \n",
+      "* run\n",
+      "\n",
+      "<< INITIALIZATION PHASE >>\n",
+      "<< output half life values >>\n",
+      "HALF \n",
+      "<< output ingestion and inhalation values >>\n",
+      "HAZARDS \n",
+      "<< set the target via MASS >>\n",
+      "MASS 1.0 2\n",
+      "Fe 8.2299760518E-01\n",
+      "C 1.7700239482E-01 \n",
+      "<< set the threshold for atoms in the inventory >>\n",
+      "MIND 100000\n",
+      "\n",
+      "<< INVENTORY PHASE >>\n",
+      "<< irradiation schedule >>\n",
+      "FLUX 1.0000000000E+00\n",
+      "TIME 1.0000000000E+01 SECS\n",
+      "ATOMS \n",
+      "FLUX 2.0000000000E+00\n",
+      "TIME 2.0000000000E+01 SECS\n",
+      "ATOMS \n",
+      "<< end of irradiation >>\n",
+      "FLUX 0.0\n",
+      "ZERO \n",
+      "TIME 3.0000000000E+01 SECS\n",
+      "ATOMS \n",
+      "<< end of cooling >>\n",
+      "\n",
+      "<< end of input >>\n",
+      "END \n",
+      "* end\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tempfile import TemporaryDirectory\n",
+    "from pathlib import Path\n",
+    "\n",
+    "fisp.add_material(\n",
+    "    material,\n",
+    "    style='mass', # this can be either 'mass' or 'fuel' following fispact keywords\n",
+    "    mass=1.0 # in kg\n",
+    "    )\n",
+    "fisp.add_irradiation_scenario(irrad_scenario)\n",
+    "\n",
+    "# Use all pypact methods to finish off the input if needed\n",
+    "fisp.inp.enableHalflifeInOutput(True)\n",
+    "fisp.inp.enableHazardsInOutput()\n",
+    "fisp.inp.setAtomsThreshold(100000)  # MIND card\n",
+    "# ...\n",
+    "\n",
+    "with TemporaryDirectory() as tmpdir:\n",
+    "    outpath = Path(f\"{tmpdir}/fispact_input.inp\")\n",
+    "    fisp.save(outpath)  # save the file to text\n",
+    "\n",
+    "    # read file contents\n",
+    "    print(outpath.read_text())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fce0012",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "f4enix",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/f4enix/input/fispact_inp.py
+++ b/src/f4enix/input/fispact_inp.py
@@ -7,6 +7,18 @@ from f4enix.input.libmanager import LibManager
 
 class FispactInp:
     def __init__(self, pypact_inp: InputData | None = None):
+        """A light-weight wrapper around pypact.InputData
+
+        Parameters
+        ----------
+        pypact_inp : InputData | None, optional
+            pass an existing pypact InputData or create a new one if None.
+
+        Attributes
+        ----------
+        inp : InputData
+            The underlying pypact InputData instance.
+        """
         if pypact_inp is None:
             self.inp = InputData()
         else:

--- a/src/f4enix/input/fispact_inp.py
+++ b/src/f4enix/input/fispact_inp.py
@@ -54,7 +54,7 @@ class FispactInp:
             # fispact natural abundances are used! be sure these are consistent
             # with the material definition
             for element in new_mat.elements:
-                self.inp.addElement(element.name, percentage=element.get_fraction())
+                self.inp.addElement(element.name, percentage=-element.get_fraction())
             if mass:
                 m = mass
             elif volume and density:

--- a/src/f4enix/input/fispact_inp.py
+++ b/src/f4enix/input/fispact_inp.py
@@ -1,0 +1,124 @@
+from pypact import InputData, to_file
+from pathlib import Path
+from f4enix.input.materials import Material
+from f4enix.core.irradiation import IrradiationScenario
+from f4enix.input.libmanager import LibManager
+
+
+class FispactInp:
+    def __init__(self, pypact_inp: InputData | None = None):
+        if pypact_inp is None:
+            self.inp = InputData()
+        else:
+            self.inp = pypact_inp
+
+    def add_material(
+        self,
+        material: Material,
+        style: str = "mass",
+        density: float | None = None,
+        mass: float | None = None,
+        volume: float | None = None,
+    ):
+        """Add a material to the FISPACT input
+
+        Parameters
+        ----------
+        material : Material
+            f4enix material definition
+        style : str, optional
+            The style in which the material is specified, either "mass" or "fuel",
+            by default "mass". This will determine if the MASS or FUEL keywords will
+            be used
+        density : float | None, optional
+            The density of the material in g/cm^3, by default None
+        mass : float | None, optional
+            The mass of the material in kg, by default None
+        volume : float | None, optional
+            The volume of the material in m^3, by default None
+
+        Raises
+        ------
+        ValueError
+            depending on the style chosen, some arguments must be provided.
+            - For "mass" style, mass must be provided or both volume and density must
+              be provided.
+            - For "fuel" style, density and mass (or volume) or both mass and volume
+              must be provided.
+
+        """
+        # Add logic to incorporate the material into the input data
+        lm = LibManager()
+        if style == "mass":
+            new_mat = material.switch_fraction("mass", lm, inplace=False)
+            # fispact natural abundances are used! be sure these are consistent
+            # with the material definition
+            for element in new_mat.elements:
+                self.inp.addElement(element.name, percentage=element.get_fraction())
+            if mass:
+                m = mass
+            elif volume and density:
+                m = volume * density / 1000  # convert g/cm^3 to kg/m^3
+            else:
+                raise ValueError(
+                    "Either mass or both volume and density must be specified for mass style materials."
+                )
+            self.inp.setMass(m)
+
+        elif style == "fuel":
+            new_mat = material.switch_fraction("atom", lm, inplace=False)
+            if density:
+                rho = density
+            elif volume and mass:
+                rho = mass / volume * 1000  #  g/cm^3
+            else:
+                raise ValueError(
+                    "Either density or both mass and volume must be specified for fuel style materials."
+                )
+
+            if volume:
+                vol = volume
+            elif mass and density:
+                vol = mass / rho
+            else:
+                raise ValueError(
+                    "Either volume or both mass and density must be specified for fuel style materials."
+                )
+
+            tad = new_mat.get_tad(rho, lm)
+            for zaid in new_mat.zaids:
+                n_atoms = zaid.fraction * tad * vol * 1e6 * 1e24
+                self.inp.addIsotope(zaid.name, n_atoms)
+        else:
+            raise ValueError(
+                f"Unknown style: {style}, only 'mass' and 'fuel' are supported."
+            )
+
+    def add_irradiation_scenario(
+        self, irr_scenario: IrradiationScenario, norm: float = 1
+    ):
+        """Add an irradiation scenario to the fispact input
+
+        Parameters
+        ----------
+        irr_scenario : IrradiationScenario
+            The irradiation scenario to be added to the fispact input.
+        norm : float, optional
+            Normalization factor for the irradiation intensities, by default 1.
+        """
+        for pulse in irr_scenario.pulses:
+            # Each intensity will need to be adjusted to the flux of the spectra
+            intensity = pulse.intensity * norm
+            self.inp.addIrradiation(pulse.time, intensity)
+        for time in irr_scenario.cooling_times:
+            self.inp.addCooling(time.time)
+
+    def save(self, filename: str | Path):
+        """Save the fispact input to a file
+
+        Parameters
+        ----------
+        filename : str | Path
+            The name or path of the file to save the fispact input to.
+        """
+        to_file(self.inp, filename)

--- a/src/f4enix/input/fispact_inp.py
+++ b/src/f4enix/input/fispact_inp.py
@@ -70,7 +70,7 @@ class FispactInp:
             if mass:
                 m = mass
             elif volume and density:
-                m = volume * density / 1000  # convert g/cm^3 to kg/m^3
+                m = volume * density * 1000  # convert g/cm^3 to kg/m^3
             else:
                 raise ValueError(
                     "Either mass or both volume and density must be specified for mass style materials."
@@ -82,7 +82,7 @@ class FispactInp:
             if density:
                 rho = density
             elif volume and mass:
-                rho = mass / volume * 1000  #  g/cm^3
+                rho = mass / volume / 1000  #  g/cm^3
             else:
                 raise ValueError(
                     "Either density or both mass and volume must be specified for fuel style materials."

--- a/src/f4enix/input/materials.py
+++ b/src/f4enix/input/materials.py
@@ -683,7 +683,7 @@ class Material:
 
     def switch_fraction(
         self, ftype: str, lib_manager: LibManager, inplace: bool = True
-    ) -> Material | None:
+    ) -> Material:
         """
         Switch between atom or mass fraction for the material card.
         If the material is already switched the command is ignored.
@@ -705,8 +705,8 @@ class Material:
 
         Returns
         -------
-        material : Material | None
-            The material with switched fractions if inplace is False, otherwise None.
+        material : Material
+            The material with switched fractions. Self if inplace is true.
 
         """
         # Get total fraction
@@ -716,8 +716,8 @@ class Material:
             if not inplace:
                 return copy.deepcopy(self)
             else:
-                # The switch is not needed, return None
-                return None
+                # The switch is not needed, return self
+                return self
 
         norm = 0
         for zaid in self.zaids:
@@ -737,7 +737,7 @@ class Material:
                 else:
                     zaid.fraction = (-1 * zaid.fraction * atom_mass) / norm
             self.elements, self._zaids = self._collapse_zaids()
-            return None
+            return self
         else:
             new_zaids = []
             for zaid in self.zaids:

--- a/src/f4enix/output/plotter.py
+++ b/src/f4enix/output/plotter.py
@@ -252,6 +252,7 @@ class MeshPlotter:
         center = np.array(center)
         increment = radians(theta_increment)
         mesh_slices = []
+        slice_normals = []
 
         if min_max_theta is None:
             angles = np.arange(0, np.pi, increment)
@@ -277,9 +278,10 @@ class MeshPlotter:
                 continue
 
             mesh_slices.append(mesh_slice)
+            slice_normals.append(normal)
 
         if self._has_stl:
-            stl_slices = self._get_stl_slices(mesh_slices)
+            stl_slices = self._get_stl_slices(mesh_slices, slice_normals)
 
         outp = []
         # build the output
@@ -456,17 +458,27 @@ class MeshPlotter:
             pl.reset_camera(bounds=bounds)
 
     def _get_stl_slices(
-        self, mesh_slices: list[pv.PolyData]
+        self, mesh_slices: list[pv.PolyData], normals: list[np.ndarray] | None = None
     ) -> Union[list[pv.PolyData], None]:
         stl_slices = []
+        if normals is None:
+            normals = [None] * len(mesh_slices)
         # get the correspondent stl_slices
-        for mesh_slice in mesh_slices:
+        for mesh_slice, normal in zip(mesh_slices, normals):
             # check it is not empty
             if len(mesh_slice[mesh_slice.array_names[0]]) == 0:
                 stl_slices.append(None)
                 continue
 
-            norm = mesh_slice.cell_normals[0]
+            if normal is None:
+                norm = mesh_slice.cell_normals[0]
+            else:
+                norm = np.array(normal)
+                norm_length = np.linalg.norm(norm)
+                if norm_length == 0:
+                    stl_slices.append(None)
+                    continue
+                norm = norm / norm_length
             stl_slice = self.stl.slice(normal=norm, origin=mesh_slice.center)
             if stl_slice.bounds is None:
                 # This may happen if the stl is smaller than the mesh

--- a/tests/fispact_inp_test.py
+++ b/tests/fispact_inp_test.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from f4enix.core.irradiation import IrradiationScenario, Pulse
+from f4enix.input.fispact_inp import FispactInp
+from f4enix.input.libmanager import LibManager
+from f4enix.input.materials import Material
+
+
+@pytest.fixture
+def simple_material() -> Material:
+    return Material.from_zaids(
+        [(1001, 0.5), (8016, 0.5)],
+        libman=LibManager(),
+        lib="31c",
+        name="testmat",
+        mat_id=1,
+    )
+
+
+@pytest.fixture
+def simple_irradiation_scenario() -> IrradiationScenario:
+    pulse_1 = Pulse(time=10, intensity=1.0)
+    pulse_2 = Pulse(time=20, intensity=2.0)
+    cooling = Pulse(time=30, intensity=0.0)
+    return IrradiationScenario(
+        pulses=[pulse_1, pulse_2],
+        cooling_times=[cooling],
+    )
+
+
+class TestFispactInp:
+    def test_valid_add_material_calls(
+        self,
+        simple_material: Material,
+    ):
+        inp = FispactInp()
+
+        with pytest.raises(ValueError):
+            inp.add_material(simple_material, style="mass")
+
+        with pytest.raises(ValueError):
+            inp.add_material(simple_material, style="fuel")
+
+        with pytest.raises(ValueError):
+            inp.add_material(simple_material, style="fuel", density=2.0)
+
+        with pytest.raises(ValueError):
+            inp.add_material(simple_material, style="fuel", volume=1.0)
+
+        with pytest.raises(ValueError):
+            inp.add_material(simple_material, style="mass", volume=1.0)
+
+        inp.add_material(simple_material, style="mass", mass=12.5)
+        inp.add_material(simple_material, style="mass", volume=1.0, density=2.0)
+        inp.add_material(simple_material, style="fuel", density=2.0, volume=1.0)
+        inp.add_material(simple_material, style="fuel", mass=12.5, volume=1.0)
+        inp.add_material(simple_material, style="fuel", mass=12.5, density=2.0)
+
+    def test_add_irradiation_scenario_adds_pulses_and_cooling_times(self):
+        inp = FispactInp()
+        inp.inp = Mock()
+
+        pulse_1 = Pulse(time=10, intensity=1.0)
+        pulse_2 = Pulse(time=20, intensity=2.0)
+        cooling = Pulse(time=30, intensity=0.0)
+        scenario = IrradiationScenario(
+            pulses=[pulse_1, pulse_2],
+            cooling_times=[cooling],
+        )
+
+        inp.add_irradiation_scenario(scenario, norm=2.0)
+
+        inp.inp.addIrradiation.assert_any_call(pulse_1.time, pulse_1.intensity * 2.0)
+        inp.inp.addIrradiation.assert_any_call(pulse_2.time, pulse_2.intensity * 2.0)
+        inp.inp.addCooling.assert_called_once_with(cooling.time)
+
+    def test_save(
+        self,
+        simple_material: Material,
+        simple_irradiation_scenario: IrradiationScenario,
+        tmpdir,
+    ):
+        inp = FispactInp()
+        inp.add_material(simple_material, style="mass", mass=1)
+        inp.add_irradiation_scenario(simple_irradiation_scenario, norm=1.0)
+        inp.save(tmpdir.join("test.inp"))

--- a/tests/fispact_inp_test.py
+++ b/tests/fispact_inp_test.py
@@ -62,7 +62,6 @@ class TestFispactInp:
 
     def test_add_irradiation_scenario_adds_pulses_and_cooling_times(self):
         inp = FispactInp()
-        inp.inp = Mock()
 
         pulse_1 = Pulse(time=10, intensity=1.0)
         pulse_2 = Pulse(time=20, intensity=2.0)
@@ -74,9 +73,7 @@ class TestFispactInp:
 
         inp.add_irradiation_scenario(scenario, norm=2.0)
 
-        inp.inp.addIrradiation.assert_any_call(pulse_1.time, pulse_1.intensity * 2.0)
-        inp.inp.addIrradiation.assert_any_call(pulse_2.time, pulse_2.intensity * 2.0)
-        inp.inp.addCooling.assert_called_once_with(cooling.time)
+        assert len(inp.inp._irradschedule) == 2
 
     def test_save(
         self,


### PR DESCRIPTION
# Description

Add a new class: `FispactInp`. A lightweight wrapper of `pypact` to be able to natively interact with f4enix objects like `Material` and `Irradiation`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating and saving FISPACT input files from materials and irradiation scenarios, including pulses, cooling periods, normalization, and output settings.
  - Added validation for material configuration options and support for mass- and fuel-based inputs.

- **Documentation**
  - Added a Jupyter notebook demonstrating FISPACT input generation and linked it from the preprocessing examples.

- **Bug Fixes**
  - Material fraction conversion now consistently returns the material object, improving reliability for chained workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->